### PR TITLE
Add mark-and-sweep garbage collector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,7 @@ path = "tests/integration/modules.rs"
 [[test]]
 name = "prelude"
 path = "tests/integration/prelude.rs"
+
+[[test]]
+name = "gc"
+path = "tests/integration/gc.rs"

--- a/runtime/builtins.c
+++ b/runtime/builtins.c
@@ -3,11 +3,368 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <setjmp.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <signal.h>
+
+// ── GC Infrastructure ─────────────────────────────────────────────────────────
+
+// Type tags for GC objects
+#define GC_TAG_OBJECT 0   // class, enum, closure, error, DI singleton
+#define GC_TAG_STRING 1   // no child pointers
+#define GC_TAG_ARRAY  2   // handle [len][cap][data_ptr]; data buffer freed on sweep
+#define GC_TAG_TRAIT  3   // [data_ptr][vtable_ptr]; trace data_ptr only
+
+typedef struct GCHeader {
+    struct GCHeader *next;    // 8B: linked list of all GC objects
+    uint32_t size;            // 4B: user data size in bytes
+    uint8_t  mark;            // 1B: 0=unmarked, 1=marked
+    uint8_t  type_tag;        // 1B: object kind
+    uint16_t field_count;     // 2B: number of 8-byte slots to scan
+} GCHeader;
+
+// Interval for binary-search pointer lookup
+typedef struct { void *start; void *end; GCHeader *header; } GCInterval;
+// Array data buffer interval
+typedef struct { void *start; void *end; void *array_handle; } GCDataInterval;
+
+// Global GC state
+static GCHeader *gc_head = NULL;
+static size_t gc_bytes_allocated = 0;
+static size_t gc_threshold = 256 * 1024;  // 256KB initial
+static void *gc_stack_bottom = NULL;
+static int gc_collecting = 0;
+
+// Mark worklist (raw malloc, not GC-tracked)
+static void **gc_worklist = NULL;
+static size_t gc_worklist_count = 0;
+static size_t gc_worklist_cap = 0;
+
+// Interval tables (rebuilt each collection)
+static GCInterval *gc_intervals = NULL;
+static size_t gc_interval_count = 0;
+static GCDataInterval *gc_data_intervals = NULL;
+static size_t gc_data_interval_count = 0;
+
+// Forward declarations
+void __pluto_gc_collect(void);
+void *__pluto_array_new(long cap);
+void __pluto_array_push(void *handle, long value);
+
+// Error handling — non-static so GC can access as root
+void *__pluto_current_error = NULL;
+
+static inline GCHeader *gc_get_header(void *user_ptr) {
+    return (GCHeader *)((char *)user_ptr - sizeof(GCHeader));
+}
+
+static void *gc_alloc(size_t user_size, uint8_t type_tag, uint16_t field_count) {
+    if (gc_stack_bottom && !gc_collecting
+        && gc_bytes_allocated + user_size + sizeof(GCHeader) > gc_threshold) {
+        __pluto_gc_collect();
+    }
+    size_t total = sizeof(GCHeader) + user_size;
+    GCHeader *h = (GCHeader *)calloc(1, total);
+    if (!h) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    h->next = gc_head;
+    gc_head = h;
+    h->size = (uint32_t)user_size;
+    h->type_tag = type_tag;
+    h->field_count = field_count;
+    h->mark = 0;
+    gc_bytes_allocated += total;
+    return (char *)h + sizeof(GCHeader);
+}
+
+// ── Interval table for pointer lookup ─────────────────────────────────────────
+
+static int gc_interval_cmp(const void *a, const void *b) {
+    const GCInterval *ia = (const GCInterval *)a;
+    const GCInterval *ib = (const GCInterval *)b;
+    if (ia->start < ib->start) return -1;
+    if (ia->start > ib->start) return 1;
+    return 0;
+}
+
+static int gc_data_interval_cmp(const void *a, const void *b) {
+    const GCDataInterval *ia = (const GCDataInterval *)a;
+    const GCDataInterval *ib = (const GCDataInterval *)b;
+    if (ia->start < ib->start) return -1;
+    if (ia->start > ib->start) return 1;
+    return 0;
+}
+
+static void gc_build_intervals(void) {
+    // Count objects
+    size_t count = 0;
+    size_t array_count = 0;
+    for (GCHeader *h = gc_head; h; h = h->next) {
+        count++;
+        if (h->type_tag == GC_TAG_ARRAY) array_count++;
+    }
+
+    gc_intervals = (GCInterval *)malloc(count * sizeof(GCInterval));
+    gc_interval_count = count;
+    gc_data_intervals = (GCDataInterval *)malloc(array_count * sizeof(GCDataInterval));
+    gc_data_interval_count = 0;
+
+    size_t i = 0;
+    for (GCHeader *h = gc_head; h; h = h->next) {
+        void *user = (char *)h + sizeof(GCHeader);
+        gc_intervals[i].start = user;
+        gc_intervals[i].end = (char *)user + h->size;
+        gc_intervals[i].header = h;
+        i++;
+
+        if (h->type_tag == GC_TAG_ARRAY && h->size >= 24) {
+            long *handle = (long *)user;
+            long cap = handle[1];
+            void *data_ptr = (void *)handle[2];
+            if (data_ptr && cap > 0) {
+                gc_data_intervals[gc_data_interval_count].start = data_ptr;
+                gc_data_intervals[gc_data_interval_count].end = (char *)data_ptr + cap * 8;
+                gc_data_intervals[gc_data_interval_count].array_handle = user;
+                gc_data_interval_count++;
+            }
+        }
+    }
+
+    qsort(gc_intervals, gc_interval_count, sizeof(GCInterval), gc_interval_cmp);
+    if (gc_data_interval_count > 0) {
+        qsort(gc_data_intervals, gc_data_interval_count, sizeof(GCDataInterval), gc_data_interval_cmp);
+    }
+}
+
+// Binary search: find GC object containing candidate pointer
+static GCHeader *gc_find_object(void *candidate) {
+    if (gc_interval_count == 0) return NULL;
+    size_t lo = 0, hi = gc_interval_count;
+    while (lo < hi) {
+        size_t mid = lo + (hi - lo) / 2;
+        if (candidate < gc_intervals[mid].start) {
+            hi = mid;
+        } else if (candidate >= gc_intervals[mid].end) {
+            lo = mid + 1;
+        } else {
+            return gc_intervals[mid].header;
+        }
+    }
+    return NULL;
+}
+
+// Binary search: find array handle owning a data buffer containing candidate
+static void *gc_find_array_owner(void *candidate) {
+    if (gc_data_interval_count == 0) return NULL;
+    size_t lo = 0, hi = gc_data_interval_count;
+    while (lo < hi) {
+        size_t mid = lo + (hi - lo) / 2;
+        if (candidate < gc_data_intervals[mid].start) {
+            hi = mid;
+        } else if (candidate >= gc_data_intervals[mid].end) {
+            lo = mid + 1;
+        } else {
+            return gc_data_intervals[mid].array_handle;
+        }
+    }
+    return NULL;
+}
+
+// ── Mark phase ────────────────────────────────────────────────────────────────
+
+static void gc_worklist_push(void *ptr) {
+    if (gc_worklist_count >= gc_worklist_cap) {
+        gc_worklist_cap = gc_worklist_cap ? gc_worklist_cap * 2 : 256;
+        gc_worklist = (void **)realloc(gc_worklist, gc_worklist_cap * sizeof(void *));
+    }
+    gc_worklist[gc_worklist_count++] = ptr;
+}
+
+static void gc_mark_object(void *user_ptr) {
+    GCHeader *h = gc_get_header(user_ptr);
+    if (h->mark) return;
+    h->mark = 1;
+    gc_worklist_push(user_ptr);
+}
+
+static void gc_trace_object(void *user_ptr) {
+    GCHeader *h = gc_get_header(user_ptr);
+    switch (h->type_tag) {
+    case GC_TAG_STRING:
+        // No child pointers
+        break;
+    case GC_TAG_ARRAY: {
+        // Array handle: [len][cap][data_ptr]
+        long *handle = (long *)user_ptr;
+        long len = handle[0];
+        long *data = (long *)handle[2];
+        // Scan elements conservatively
+        for (long i = 0; i < len; i++) {
+            void *candidate = (void *)data[i];
+            GCHeader *child = gc_find_object(candidate);
+            if (child && !child->mark) {
+                void *child_user = (char *)child + sizeof(GCHeader);
+                gc_mark_object(child_user);
+            }
+        }
+        break;
+    }
+    case GC_TAG_TRAIT: {
+        // Trait handle: [data_ptr][vtable_ptr]
+        long *slots = (long *)user_ptr;
+        void *data_ptr = (void *)slots[0];
+        GCHeader *child = gc_find_object(data_ptr);
+        if (child && !child->mark) {
+            void *child_user = (char *)child + sizeof(GCHeader);
+            gc_mark_object(child_user);
+        }
+        break;
+    }
+    case GC_TAG_OBJECT:
+    default: {
+        // Scan all 8-byte slots conservatively
+        long *slots = (long *)user_ptr;
+        uint16_t fc = h->field_count;
+        for (uint16_t i = 0; i < fc; i++) {
+            void *candidate = (void *)slots[i];
+            // Check GC objects
+            GCHeader *child = gc_find_object(candidate);
+            if (child && !child->mark) {
+                void *child_user = (char *)child + sizeof(GCHeader);
+                gc_mark_object(child_user);
+            }
+            // Check array data buffers
+            void *arr_owner = gc_find_array_owner(candidate);
+            if (arr_owner) {
+                GCHeader *arr_h = gc_get_header(arr_owner);
+                if (!arr_h->mark) {
+                    gc_mark_object(arr_owner);
+                }
+            }
+        }
+        break;
+    }
+    }
+}
+
+static void gc_mark_candidate(void *candidate) {
+    // Check if candidate points into a GC object
+    GCHeader *h = gc_find_object(candidate);
+    if (h && !h->mark) {
+        void *user = (char *)h + sizeof(GCHeader);
+        gc_mark_object(user);
+    }
+    // Check if candidate points into an array data buffer
+    void *arr_owner = gc_find_array_owner(candidate);
+    if (arr_owner) {
+        GCHeader *arr_h = gc_get_header(arr_owner);
+        if (!arr_h->mark) {
+            gc_mark_object(arr_owner);
+        }
+    }
+}
+
+void __pluto_gc_collect(void) {
+    gc_collecting = 1;
+
+    // Build interval tables
+    gc_build_intervals();
+
+    // Reset worklist
+    gc_worklist_count = 0;
+
+    // 1. Flush registers to stack via setjmp
+    jmp_buf regs;
+    setjmp(regs);
+
+    // 2. Scan jmp_buf as potential roots
+    {
+        long *p = (long *)&regs;
+        size_t n = sizeof(regs) / (sizeof(long));
+        for (size_t i = 0; i < n; i++) {
+            gc_mark_candidate((void *)p[i]);
+        }
+    }
+
+    // 3. Scan stack (direction-agnostic)
+    {
+        void *stack_top;
+        // Get current stack pointer
+        volatile long anchor = 0;
+        (void)anchor;
+        stack_top = (void *)&anchor;
+
+        void *lo = stack_top < gc_stack_bottom ? stack_top : gc_stack_bottom;
+        void *hi = stack_top < gc_stack_bottom ? gc_stack_bottom : stack_top;
+        // Align to 8-byte boundary
+        lo = (void *)(((size_t)lo) & ~7UL);
+        for (long *p = (long *)lo; (void *)p < hi; p++) {
+            gc_mark_candidate((void *)*p);
+        }
+    }
+
+    // 4. Scan error TLS as explicit root
+    if (__pluto_current_error) {
+        gc_mark_candidate(__pluto_current_error);
+    }
+
+    // 5. Drain worklist (breadth-first trace)
+    while (gc_worklist_count > 0) {
+        void *obj = gc_worklist[--gc_worklist_count];
+        gc_trace_object(obj);
+    }
+
+    // ── Sweep phase ───────────────────────────────────────────────────────
+    GCHeader **pp = &gc_head;
+    size_t freed_bytes = 0;
+    while (*pp) {
+        GCHeader *h = *pp;
+        if (!h->mark) {
+            *pp = h->next;
+            size_t total = sizeof(GCHeader) + h->size;
+            // Free array data buffer if applicable
+            if (h->type_tag == GC_TAG_ARRAY && h->size >= 24) {
+                long *handle = (long *)((char *)h + sizeof(GCHeader));
+                void *data_ptr = (void *)handle[2];
+                if (data_ptr) free(data_ptr);
+            }
+            free(h);
+            freed_bytes += total;
+        } else {
+            h->mark = 0;  // Clear for next cycle
+            pp = &h->next;
+        }
+    }
+
+    gc_bytes_allocated -= freed_bytes;
+    size_t surviving = gc_bytes_allocated;
+    gc_threshold = surviving * 2;
+    if (gc_threshold < 256 * 1024) gc_threshold = 256 * 1024;
+
+    // Free interval tables and worklist
+    free(gc_intervals);
+    gc_intervals = NULL;
+    gc_interval_count = 0;
+    free(gc_data_intervals);
+    gc_data_intervals = NULL;
+    gc_data_interval_count = 0;
+    free(gc_worklist);
+    gc_worklist = NULL;
+    gc_worklist_count = 0;
+    gc_worklist_cap = 0;
+
+    gc_collecting = 0;
+}
+
+void __pluto_gc_init(void) {
+    volatile long anchor = 0;
+    (void)anchor;
+    gc_stack_bottom = (void *)&anchor;
+}
+
+// ── Print functions ───────────────────────────────────────────────────────────
 
 void __pluto_print_int(long value) {
     printf("%ld\n", value);
@@ -31,24 +388,26 @@ void __pluto_print_string_no_newline(void *header) {
     printf("%s", data);
 }
 
+// ── Memory allocation ─────────────────────────────────────────────────────────
+
 void *__pluto_alloc(long size) {
     if (size == 0) size = 8;
-    void *ptr = calloc(1, size);
-    if (!ptr) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
-    return ptr;
+    uint16_t field_count = (uint16_t)(size / 8);
+    return gc_alloc((size_t)size, GC_TAG_OBJECT, field_count);
 }
 
 void *__pluto_trait_wrap(long data_ptr, long vtable_ptr) {
-    long *handle = (long *)malloc(16);
-    if (!handle) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    long *handle = (long *)gc_alloc(16, GC_TAG_TRAIT, 2);
     handle[0] = data_ptr;
     handle[1] = vtable_ptr;
     return handle;
 }
 
+// ── String functions ──────────────────────────────────────────────────────────
+
 void *__pluto_string_new(const char *data, long len) {
-    void *header = malloc(8 + len + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + len + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = len;
     memcpy((char *)header + 8, data, len);
     ((char *)header)[8 + len] = '\0';
@@ -59,8 +418,8 @@ void *__pluto_string_concat(void *a, void *b) {
     long len_a = *(long *)a;
     long len_b = *(long *)b;
     long total = len_a + len_b;
-    void *header = malloc(8 + total + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + total + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = total;
     memcpy((char *)header + 8, (char *)a + 8, len_a);
     memcpy((char *)header + 8 + len_a, (char *)b + 8, len_b);
@@ -79,14 +438,14 @@ long __pluto_string_len(void *s) {
     return *(long *)s;
 }
 
-// Array runtime functions
+// ── Array runtime functions ───────────────────────────────────────────────────
 // Handle layout (24 bytes): [len: long] [cap: long] [data_ptr: long*]
 
 void *__pluto_array_new(long cap) {
-    long *handle = (long *)malloc(24);
-    if (!handle) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    long *handle = (long *)gc_alloc(24, GC_TAG_ARRAY, 3);
     handle[0] = 0;   // len
     handle[1] = cap;  // cap
+    // Data buffer is NOT GC-tracked — raw malloc/realloc
     long *data = (long *)malloc(cap * 8);
     if (!data) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
     handle[2] = (long)data;
@@ -136,18 +495,17 @@ long __pluto_array_len(void *handle) {
     return ((long *)handle)[0];
 }
 
-// String utility functions
+// ── String utility functions ──────────────────────────────────────────────────
 
 void *__pluto_string_substring(void *s, long start, long len) {
     long slen = *(long *)s;
     const char *data = (const char *)s + 8;
-    // Clamp start and len to valid range
     if (start < 0) start = 0;
     if (start > slen) start = slen;
     if (len < 0) len = 0;
     if (start + len > slen) len = slen - start;
-    void *header = malloc(8 + len + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + len + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = len;
     memcpy((char *)header + 8, data + start, len);
     ((char *)header)[8 + len] = '\0';
@@ -200,8 +558,8 @@ void *__pluto_string_trim(void *s) {
     while (start < end && (data[start] == ' ' || data[start] == '\t' || data[start] == '\n' || data[start] == '\r')) start++;
     while (end > start && (data[end-1] == ' ' || data[end-1] == '\t' || data[end-1] == '\n' || data[end-1] == '\r')) end--;
     long newlen = end - start;
-    void *header = malloc(8 + newlen + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + newlen + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = newlen;
     memcpy((char *)header + 8, data + start, newlen);
     ((char *)header)[8 + newlen] = '\0';
@@ -211,8 +569,8 @@ void *__pluto_string_trim(void *s) {
 void *__pluto_string_to_upper(void *s) {
     long slen = *(long *)s;
     const char *data = (const char *)s + 8;
-    void *header = malloc(8 + slen + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + slen + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = slen;
     char *out = (char *)header + 8;
     for (long i = 0; i < slen; i++) {
@@ -225,8 +583,8 @@ void *__pluto_string_to_upper(void *s) {
 void *__pluto_string_to_lower(void *s) {
     long slen = *(long *)s;
     const char *data = (const char *)s + 8;
-    void *header = malloc(8 + slen + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + slen + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = slen;
     char *out = (char *)header + 8;
     for (long i = 0; i < slen; i++) {
@@ -243,16 +601,14 @@ void *__pluto_string_replace(void *s, void *old, void *new_str) {
     const char *sdata = (const char *)s + 8;
     const char *odata = (const char *)old + 8;
     const char *ndata = (const char *)new_str + 8;
-    // Empty old → return copy unchanged
     if (olen == 0) {
-        void *header = malloc(8 + slen + 1);
-        if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+        size_t alloc_size = 8 + slen + 1;
+        void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
         *(long *)header = slen;
         memcpy((char *)header + 8, sdata, slen);
         ((char *)header)[8 + slen] = '\0';
         return header;
     }
-    // Count occurrences
     long count = 0;
     const char *p = sdata;
     long remaining = slen;
@@ -264,8 +620,8 @@ void *__pluto_string_replace(void *s, void *old, void *new_str) {
         p = found + olen;
     }
     long newlen = slen + count * (nlen - olen);
-    void *header = malloc(8 + newlen + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + newlen + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = newlen;
     char *out = (char *)header + 8;
     p = sdata;
@@ -293,10 +649,8 @@ void *__pluto_string_split(void *s, void *delim) {
     const char *ddata = (const char *)delim + 8;
     void *arr = __pluto_array_new(4);
     if (dlen == 0) {
-        // Split into individual characters
         for (long i = 0; i < slen; i++) {
-            void *ch = malloc(8 + 1 + 1);
-            if (!ch) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+            void *ch = gc_alloc(8 + 1 + 1, GC_TAG_STRING, 0);
             *(long *)ch = 1;
             ((char *)ch)[8] = sdata[i];
             ((char *)ch)[9] = '\0';
@@ -308,9 +662,8 @@ void *__pluto_string_split(void *s, void *delim) {
     long remaining = slen;
     while (1) {
         if (remaining < dlen) {
-            // Last segment
-            void *seg = malloc(8 + remaining + 1);
-            if (!seg) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+            size_t alloc_size = 8 + remaining + 1;
+            void *seg = gc_alloc(alloc_size, GC_TAG_STRING, 0);
             *(long *)seg = remaining;
             memcpy((char *)seg + 8, p, remaining);
             ((char *)seg)[8 + remaining] = '\0';
@@ -319,8 +672,8 @@ void *__pluto_string_split(void *s, void *delim) {
         }
         const char *found = (const char *)memmem(p, remaining, ddata, dlen);
         if (!found) {
-            void *seg = malloc(8 + remaining + 1);
-            if (!seg) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+            size_t alloc_size = 8 + remaining + 1;
+            void *seg = gc_alloc(alloc_size, GC_TAG_STRING, 0);
             *(long *)seg = remaining;
             memcpy((char *)seg + 8, p, remaining);
             ((char *)seg)[8 + remaining] = '\0';
@@ -328,8 +681,8 @@ void *__pluto_string_split(void *s, void *delim) {
             break;
         }
         long seglen = found - p;
-        void *seg = malloc(8 + seglen + 1);
-        if (!seg) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+        size_t alloc_size = 8 + seglen + 1;
+        void *seg = gc_alloc(alloc_size, GC_TAG_STRING, 0);
         *(long *)seg = seglen;
         memcpy((char *)seg + 8, p, seglen);
         ((char *)seg)[8 + seglen] = '\0';
@@ -347,8 +700,7 @@ void *__pluto_string_char_at(void *s, long index) {
         exit(1);
     }
     const char *data = (const char *)s + 8;
-    void *header = malloc(8 + 1 + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    void *header = gc_alloc(8 + 1 + 1, GC_TAG_STRING, 0);
     *(long *)header = 1;
     ((char *)header)[8] = data[index];
     ((char *)header)[9] = '\0';
@@ -357,8 +709,8 @@ void *__pluto_string_char_at(void *s, long index) {
 
 void *__pluto_int_to_string(long value) {
     int len = snprintf(NULL, 0, "%ld", value);
-    void *header = malloc(8 + len + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + len + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = len;
     snprintf((char *)header + 8, len + 1, "%ld", value);
     return header;
@@ -366,8 +718,8 @@ void *__pluto_int_to_string(long value) {
 
 void *__pluto_float_to_string(double value) {
     int len = snprintf(NULL, 0, "%f", value);
-    void *header = malloc(8 + len + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + len + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = len;
     snprintf((char *)header + 8, len + 1, "%f", value);
     return header;
@@ -376,16 +728,15 @@ void *__pluto_float_to_string(double value) {
 void *__pluto_bool_to_string(int value) {
     const char *s = value ? "true" : "false";
     long len = value ? 4 : 5;
-    void *header = malloc(8 + len + 1);
-    if (!header) { fprintf(stderr, "pluto: out of memory\n"); exit(1); }
+    size_t alloc_size = 8 + len + 1;
+    void *header = gc_alloc(alloc_size, GC_TAG_STRING, 0);
     *(long *)header = len;
     memcpy((char *)header + 8, s, len);
     ((char *)header)[8 + len] = '\0';
     return header;
 }
 
-// Error handling runtime — thread-local error state (single-threaded for MVP)
-static void *__pluto_current_error = NULL;
+// ── Error handling runtime ────────────────────────────────────────────────────
 
 void __pluto_raise_error(void *error_obj) {
     __pluto_current_error = error_obj;
@@ -403,7 +754,7 @@ void __pluto_clear_error() {
     __pluto_current_error = NULL;
 }
 
-// Socket runtime — POSIX sockets for networking
+// ── Socket runtime — POSIX sockets for networking ─────────────────────────────
 
 __attribute__((constructor))
 static void __pluto_ignore_sigpipe(void) {

--- a/src/codegen/lower.rs
+++ b/src/codegen/lower.rs
@@ -1303,6 +1303,11 @@ pub fn lower_function(
         expected_return_type,
     };
 
+    // Initialize GC at start of non-app main
+    if is_main {
+        ctx.call_runtime_void("__pluto_gc_init", &[]);
+    }
+
     let mut terminated = false;
     for stmt in &func.body.node.stmts {
         if terminated {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -336,6 +336,10 @@ pub fn codegen(program: &Program, env: &TypeEnv) -> Result<Vec<u8>, CompileError
             builder.switch_to_block(entry_block);
             builder.seal_block(entry_block);
 
+            // Initialize GC before any allocations
+            let gc_init_ref = module.declare_func_in_func(runtime.get("__pluto_gc_init"), builder.func);
+            builder.ins().call(gc_init_ref, &[]);
+
             let alloc_ref = module.declare_func_in_func(runtime.get("__pluto_alloc"), builder.func);
 
             // Create singletons in topological order

--- a/src/codegen/runtime.rs
+++ b/src/codegen/runtime.rs
@@ -50,6 +50,9 @@ impl RuntimeRegistry {
         reg.declare(module, "__pluto_array_set", &[types::I64, types::I64, types::I64], &[])?;
         reg.declare(module, "__pluto_array_len", &[types::I64], &[types::I64])?;
 
+        // GC
+        reg.declare(module, "__pluto_gc_init", &[], &[])?;
+
         Ok(reg)
     }
 

--- a/tests/integration/gc.rs
+++ b/tests/integration/gc.rs
@@ -1,0 +1,325 @@
+mod common;
+use common::compile_and_run_stdout;
+
+#[test]
+fn gc_string_pressure() {
+    // 10k string concatenations in a loop — old strings become garbage
+    let out = compile_and_run_stdout(r#"
+fn main() {
+    let s = "start"
+    let i = 0
+    while i < 10000 {
+        s = s + "x"
+        i = i + 1
+    }
+    print(s.len())
+}
+"#);
+    assert_eq!(out.trim(), "10005");
+}
+
+#[test]
+fn gc_class_allocation_loop() {
+    // Allocate 10k class instances in a loop; only the last one is retained
+    let out = compile_and_run_stdout(r#"
+class Box {
+    value: int
+}
+
+fn main() {
+    let b = Box { value: 0 }
+    let i = 0
+    while i < 10000 {
+        b = Box { value: i }
+        i = i + 1
+    }
+    print(b.value)
+}
+"#);
+    assert_eq!(out.trim(), "9999");
+}
+
+#[test]
+fn gc_array_of_classes() {
+    // Array holding class pointers — GC must trace through array to keep classes alive
+    let out = compile_and_run_stdout(r#"
+class Point {
+    x: int
+    y: int
+}
+
+fn main() {
+    let first = Point { x: 0, y: 0 }
+    let arr = [first]
+    let i = 1
+    while i < 100 {
+        arr.push(Point { x: i, y: i * 2 })
+        i = i + 1
+    }
+    // Create garbage to trigger GC
+    let j = 0
+    while j < 10000 {
+        let tmp = Point { x: j, y: j }
+        j = j + 1
+    }
+    // Array elements must survive
+    let p = arr[99]
+    print(p.x)
+    print(p.y)
+}
+"#);
+    assert_eq!(out.trim(), "99\n198");
+}
+
+#[test]
+fn gc_closure_captures_survive() {
+    // Closure captures heap objects; throwaway closures create garbage
+    let out = compile_and_run_stdout(r#"
+fn make_adder(n: int) fn(int) int {
+    return (x: int) => n + x
+}
+
+fn main() {
+    let add5 = make_adder(5)
+    // Create garbage closures
+    let i = 0
+    while i < 10000 {
+        let tmp = make_adder(i)
+        i = i + 1
+    }
+    // Original closure must still work
+    print(add5(10))
+}
+"#);
+    assert_eq!(out.trim(), "15");
+}
+
+#[test]
+fn gc_enum_allocation_pressure() {
+    // Allocate many enum variants in a loop
+    let out = compile_and_run_stdout(r#"
+enum Shape {
+    Circle { radius: int }
+    Rect { w: int, h: int }
+}
+
+fn area(s: Shape) int {
+    match s {
+        Shape.Circle { radius } {
+            return radius * radius
+        }
+        Shape.Rect { w, h } {
+            return w * h
+        }
+    }
+}
+
+fn main() {
+    let total = 0
+    let i = 0
+    while i < 10000 {
+        let s = Shape.Circle { radius: 1 }
+        total = total + area(s)
+        i = i + 1
+    }
+    print(total)
+}
+"#);
+    assert_eq!(out.trim(), "10000");
+}
+
+#[test]
+fn gc_string_interpolation_pressure() {
+    // String interpolation creates intermediate strings that become garbage
+    let out = compile_and_run_stdout(r#"
+fn main() {
+    let i = 0
+    let last = ""
+    while i < 5000 {
+        last = "item_{i}"
+        i = i + 1
+    }
+    print(last)
+}
+"#);
+    assert_eq!(out.trim(), "item_4999");
+}
+
+#[test]
+fn gc_di_app_with_pressure() {
+    // DI app with GC pressure inside app method
+    let out = compile_and_run_stdout(r#"
+class Counter {
+    count: int
+
+    fn increment(self) {
+        self.count = self.count + 1
+    }
+
+    fn get(self) int {
+        return self.count
+    }
+}
+
+app MyApp[counter: Counter] {
+    fn main(self) {
+        let i = 0
+        while i < 10000 {
+            // Create garbage strings
+            let s = "garbage_{i}"
+            self.counter.increment()
+            i = i + 1
+        }
+        print(self.counter.get())
+    }
+}
+"#);
+    assert_eq!(out.trim(), "10000");
+}
+
+#[test]
+fn gc_deep_object_graph() {
+    // Build a chain of 10k nodes via array, validates worklist-based (non-recursive) mark
+    let out = compile_and_run_stdout(r#"
+class Node {
+    value: int
+    next_idx: int
+}
+
+fn main() {
+    let first = Node { value: 0, next_idx: -1 }
+    let nodes = [first]
+    let i = 1
+    while i < 10000 {
+        let prev_idx = i - 1
+        nodes.push(Node { value: i, next_idx: prev_idx })
+        i = i + 1
+    }
+    // Create garbage to trigger GC
+    let j = 0
+    while j < 5000 {
+        let tmp = Node { value: j, next_idx: -1 }
+        j = j + 1
+    }
+    // Walk the chain via indices to verify integrity
+    let count = 0
+    let idx = 9999
+    while idx >= 0 {
+        let n = nodes[idx]
+        count = count + 1
+        idx = n.next_idx
+    }
+    print(count)
+}
+"#);
+    assert_eq!(out.trim(), "10000");
+}
+
+#[test]
+fn gc_string_concat_pressure() {
+    // Many string concatenations creating lots of intermediate garbage
+    let out = compile_and_run_stdout(r#"
+fn main() {
+    let i = 0
+    let total_len = 0
+    while i < 5000 {
+        let s = "a" + "b" + "c" + "d" + "e"
+        total_len = total_len + s.len()
+        i = i + 1
+    }
+    print(total_len)
+}
+"#);
+    assert_eq!(out.trim(), "25000");
+}
+
+#[test]
+fn gc_retained_objects_survive() {
+    // Multiple objects retained across GC cycles
+    let out = compile_and_run_stdout(r#"
+class Pair {
+    a: string
+    b: string
+}
+
+fn main() {
+    let p1 = Pair { a: "hello", b: "world" }
+    let p2 = Pair { a: "foo", b: "bar" }
+    // Create garbage to trigger GC
+    let i = 0
+    while i < 10000 {
+        let tmp = Pair { a: "x", b: "y" }
+        i = i + 1
+    }
+    // Retained objects must survive
+    print(p1.a)
+    print(p1.b)
+    print(p2.a)
+    print(p2.b)
+}
+"#);
+    assert_eq!(out.trim(), "hello\nworld\nfoo\nbar");
+}
+
+#[test]
+fn gc_array_growth_under_pressure() {
+    // Array that grows (realloc) while GC is active
+    let out = compile_and_run_stdout(r#"
+fn main() {
+    let arr = ["seed"]
+    let i = 1
+    while i < 5000 {
+        arr.push("item_{i}")
+        i = i + 1
+    }
+    print(arr.len())
+    print(arr[0])
+    print(arr[4999])
+}
+"#);
+    assert_eq!(out.trim(), "5000\nseed\nitem_4999");
+}
+
+#[test]
+fn gc_trait_objects_survive() {
+    // Trait objects (data_ptr + vtable_ptr) must be traced correctly
+    let out = compile_and_run_stdout(r#"
+trait Greeter {
+    fn greet(self) string
+}
+
+class English impl Greeter {
+    tag: int
+
+    fn greet(self) string {
+        return "hello"
+    }
+}
+
+class Spanish impl Greeter {
+    tag: int
+
+    fn greet(self) string {
+        return "hola"
+    }
+}
+
+fn get_greeting(g: Greeter) string {
+    return g.greet()
+}
+
+fn main() {
+    let e = English { tag: 1 }
+    let s = Spanish { tag: 2 }
+    // Create garbage to potentially trigger GC
+    let i = 0
+    while i < 10000 {
+        let tmp = English { tag: i }
+        i = i + 1
+    }
+    print(get_greeting(e))
+    print(get_greeting(s))
+}
+"#);
+    assert_eq!(out.trim(), "hello\nhola");
+}


### PR DESCRIPTION
## Summary
- Implement stop-the-world mark-and-sweep GC with conservative stack scanning
- All heap allocations (strings, arrays, classes, closures, enums, traits, errors) go through a GC allocator with 16-byte object headers
- Collection uses interval-based binary search for pointer validation (handles interior pointers), worklist-based non-recursive traversal, and direction-agnostic stack scanning with register flushing via setjmp
- GC threshold auto-adjusts: `max(256KB, 2 * surviving_bytes)`
- Array data buffers remain raw malloc/realloc (freed during sweep when owning handle is collected)

## Changes
- `runtime/builtins.c` — GC infrastructure + all allocation functions use `gc_alloc` instead of raw malloc/calloc
- `src/codegen/runtime.rs` — declare `__pluto_gc_init`
- `src/codegen/mod.rs` — call `__pluto_gc_init()` in synthetic main (app/DI path)
- `src/codegen/lower.rs` — call `__pluto_gc_init()` in non-app main
- `tests/integration/gc.rs` — 12 stress tests (strings, classes, arrays, closures, enums, interpolation, DI, deep graphs, traits)

## Test plan
- [x] All 138 unit tests pass
- [x] All 254 existing integration tests pass unchanged (GC is transparent)
- [x] All 12 new GC stress tests pass
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)