### PR TITLE
Add --version flag to plutoc CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Parser)]
-#[command(name = "plutoc", about = "The Pluto compiler")]
+#[command(name = "plutoc", version, about = "The Pluto compiler")]
 struct Cli {
     /// Path to stdlib root directory
     #[arg(long, global = true)]


### PR DESCRIPTION
## Summary
- Adds `version` to the clap `#[command]` attribute so `plutoc --version` prints the version from `Cargo.toml`

## Test plan
- [x] `plutoc --version` outputs `plutoc 0.1.0`
- [x] All 567 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)