### PR TITLE
Enrich DerivedInfo with full type data

### DIFF
--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -1176,23 +1176,23 @@ impl PlutoMcp {
             }
             DeclKind::Class => {
                 let cls = decl.as_class().unwrap();
-                serde_json::to_string_pretty(&serialize::class_detail(cls))
+                serde_json::to_string_pretty(&serialize::class_detail(cls, module))
             }
             DeclKind::Enum => {
                 let en = decl.as_enum().unwrap();
-                serde_json::to_string_pretty(&serialize::enum_detail(en))
+                serde_json::to_string_pretty(&serialize::enum_detail(en, module))
             }
             DeclKind::Trait => {
                 let tr = decl.as_trait().unwrap();
-                serde_json::to_string_pretty(&serialize::trait_detail(tr))
+                serde_json::to_string_pretty(&serialize::trait_detail(tr, module))
             }
             DeclKind::Error => {
                 let err = decl.as_error().unwrap();
-                serde_json::to_string_pretty(&serialize::error_decl_detail(err))
+                serde_json::to_string_pretty(&serialize::error_decl_detail(err, module))
             }
             DeclKind::App => {
                 let app = decl.as_app().unwrap();
-                serde_json::to_string_pretty(&serialize::app_detail(app))
+                serde_json::to_string_pretty(&serialize::app_detail(app, module))
             }
             other => {
                 serde_json::to_string_pretty(&serde_json::json!({

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -11,7 +11,11 @@ pub use error::SdkError;
 pub use module::Module;
 
 // Re-export key plutoc types for convenience
-pub use plutoc::derived::{DerivedInfo, ErrorRef, ResolvedSignature};
+pub use plutoc::derived::{
+    DerivedInfo, ErrorRef, ResolvedSignature,
+    ResolvedClassInfo, ResolvedTraitInfo, ResolvedEnumInfo,
+    ResolvedErrorInfo, ResolvedFieldInfo, ResolvedVariantInfo,
+};
 pub use plutoc::parser::ast::Program;
 pub use plutoc::span::{Span, Spanned};
 pub use plutoc::typeck::types::PlutoType;
@@ -65,10 +69,7 @@ mod tests {
     }
 
     fn empty_derived() -> DerivedInfo {
-        DerivedInfo {
-            fn_error_sets: Default::default(),
-            fn_signatures: Default::default(),
-        }
+        DerivedInfo::default()
     }
 
     /// Parse a source string into a Program (no typeck).

--- a/sdk/src/module.rs
+++ b/sdk/src/module.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 use uuid::Uuid;
 
-use plutoc::derived::{DerivedInfo, ErrorRef, ResolvedSignature};
+use plutoc::derived::{
+    DerivedInfo, ErrorRef, ResolvedClassInfo, ResolvedEnumInfo, ResolvedErrorInfo,
+    ResolvedSignature, ResolvedTraitInfo,
+};
 use plutoc::parser::ast::Program;
 use plutoc::span::Span;
 
@@ -236,6 +239,40 @@ impl Module {
     /// Access the raw derived info.
     pub fn derived(&self) -> &DerivedInfo {
         &self.derived
+    }
+
+    /// Get resolved class info by UUID.
+    pub fn class_info_of(&self, id: Uuid) -> Option<&ResolvedClassInfo> {
+        self.derived.class_infos.get(&id)
+    }
+
+    /// Get resolved trait info by UUID.
+    pub fn trait_info_of(&self, id: Uuid) -> Option<&ResolvedTraitInfo> {
+        self.derived.trait_infos.get(&id)
+    }
+
+    /// Get resolved enum info by UUID.
+    pub fn enum_info_of(&self, id: Uuid) -> Option<&ResolvedEnumInfo> {
+        self.derived.enum_infos.get(&id)
+    }
+
+    /// Get resolved error info by UUID.
+    pub fn error_info_of(&self, id: Uuid) -> Option<&ResolvedErrorInfo> {
+        self.derived.error_infos.get(&id)
+    }
+
+    /// Get DI instantiation order (class UUIDs in topological order).
+    pub fn di_order(&self) -> &[Uuid] {
+        &self.derived.di_order
+    }
+
+    /// Get the list of class UUIDs that implement a given trait.
+    pub fn trait_implementors_of(&self, trait_id: Uuid) -> &[Uuid] {
+        self.derived
+            .trait_implementors
+            .get(&trait_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
     }
 
     // --- Internal helpers ---

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -222,10 +222,7 @@ mod tests {
     }
 
     fn empty_derived() -> DerivedInfo {
-        DerivedInfo {
-            fn_error_sets: Default::default(),
-            fn_signatures: Default::default(),
-        }
+        DerivedInfo::default()
     }
 
     #[test]
@@ -463,6 +460,7 @@ fn main() {
         let derived = DerivedInfo {
             fn_error_sets,
             fn_signatures,
+            ..DerivedInfo::default()
         };
 
         let bytes = serialize_program(&program, source, &derived).unwrap();

--- a/src/derived.rs
+++ b/src/derived.rs
@@ -2,14 +2,14 @@
 //!
 //! This module bridges the gap between the compiler's transient type analysis
 //! (stored in `TypeEnv`) and the serialized PLTO binary format. It captures
-//! error sets, resolved function signatures, and fallibility — keyed by AST
-//! node UUID — so that consumers (like the SDK) can query type information
-//! without re-running the compiler.
+//! error sets, resolved function signatures, fallibility, class/trait/enum/error
+//! type information, and DI wiring — keyed by AST node UUID — so that consumers
+//! (like the SDK) can query type information without re-running the compiler.
 
 use std::collections::BTreeMap;
 use uuid::Uuid;
 
-use crate::parser::ast::Program;
+use crate::parser::ast::{Lifecycle, Program};
 use crate::typeck::env::TypeEnv;
 use crate::typeck::types::PlutoType;
 
@@ -29,6 +29,24 @@ pub struct DerivedInfo {
     pub fn_error_sets: BTreeMap<Uuid, Vec<ErrorRef>>,
     /// Resolved function signatures: function UUID -> resolved param/return types.
     pub fn_signatures: BTreeMap<Uuid, ResolvedSignature>,
+    /// Resolved class type info: class UUID -> fields, methods, traits, lifecycle.
+    #[serde(default)]
+    pub class_infos: BTreeMap<Uuid, ResolvedClassInfo>,
+    /// Resolved trait type info: trait UUID -> methods with signatures.
+    #[serde(default)]
+    pub trait_infos: BTreeMap<Uuid, ResolvedTraitInfo>,
+    /// Resolved enum type info: enum UUID -> variants with fields.
+    #[serde(default)]
+    pub enum_infos: BTreeMap<Uuid, ResolvedEnumInfo>,
+    /// Resolved error type info: error UUID -> fields with types.
+    #[serde(default)]
+    pub error_infos: BTreeMap<Uuid, ResolvedErrorInfo>,
+    /// DI instantiation order (class UUIDs in topological order).
+    #[serde(default)]
+    pub di_order: Vec<Uuid>,
+    /// Trait UUID -> list of class UUIDs that implement it.
+    #[serde(default)]
+    pub trait_implementors: BTreeMap<Uuid, Vec<Uuid>>,
 }
 
 /// A reference to an error declaration.
@@ -46,6 +64,51 @@ pub struct ResolvedSignature {
     pub param_types: Vec<PlutoType>,
     pub return_type: PlutoType,
     pub is_fallible: bool,
+}
+
+/// Resolved class info extracted from TypeEnv.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ResolvedClassInfo {
+    pub fields: Vec<ResolvedFieldInfo>,
+    pub methods: Vec<(String, ResolvedSignature)>,
+    pub impl_traits: Vec<String>,
+    pub lifecycle: Lifecycle,
+    pub is_pub: bool,
+}
+
+/// A single resolved field with its concrete type.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ResolvedFieldInfo {
+    pub name: String,
+    pub ty: PlutoType,
+    pub is_injected: bool,
+}
+
+/// Resolved trait info extracted from TypeEnv.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ResolvedTraitInfo {
+    pub methods: Vec<(String, ResolvedSignature)>,
+    pub default_methods: Vec<String>,
+    pub implementors: Vec<Uuid>,
+}
+
+/// Resolved enum info extracted from TypeEnv.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ResolvedEnumInfo {
+    pub variants: Vec<ResolvedVariantInfo>,
+}
+
+/// A single resolved enum variant with its fields.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ResolvedVariantInfo {
+    pub name: String,
+    pub fields: Vec<ResolvedFieldInfo>,
+}
+
+/// Resolved error declaration info extracted from TypeEnv.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ResolvedErrorInfo {
+    pub fields: Vec<ResolvedFieldInfo>,
 }
 
 impl DerivedInfo {
@@ -113,9 +176,172 @@ impl DerivedInfo {
             }
         }
 
+        // Build name->UUID maps for classes, traits, enums
+        let class_name_to_uuid: BTreeMap<&str, Uuid> = program
+            .classes
+            .iter()
+            .map(|c| (c.node.name.node.as_str(), c.node.id))
+            .collect();
+
+        // Build class_infos
+        let mut class_infos = BTreeMap::new();
+        for class in &program.classes {
+            let class_name = &class.node.name.node;
+            if let Some(ci) = env.classes.get(class_name.as_str()) {
+                let fields: Vec<ResolvedFieldInfo> = ci
+                    .fields
+                    .iter()
+                    .map(|(name, ty, is_injected)| ResolvedFieldInfo {
+                        name: name.clone(),
+                        ty: ty.clone(),
+                        is_injected: *is_injected,
+                    })
+                    .collect();
+
+                let methods: Vec<(String, ResolvedSignature)> = ci
+                    .methods
+                    .iter()
+                    .filter_map(|method_name| {
+                        let key = typeenv_key(method_name, Some(class_name));
+                        env.functions.get(&key).map(|sig| {
+                            let is_fallible = env
+                                .fn_errors
+                                .get(&key)
+                                .is_some_and(|errs| !errs.is_empty());
+                            (
+                                method_name.clone(),
+                                ResolvedSignature {
+                                    param_types: sig.params.clone(),
+                                    return_type: sig.return_type.clone(),
+                                    is_fallible,
+                                },
+                            )
+                        })
+                    })
+                    .collect();
+
+                class_infos.insert(
+                    class.node.id,
+                    ResolvedClassInfo {
+                        fields,
+                        methods,
+                        impl_traits: ci.impl_traits.clone(),
+                        lifecycle: ci.lifecycle.clone(),
+                        is_pub: class.node.is_pub,
+                    },
+                );
+            }
+        }
+
+        // Build trait_infos + trait_implementors
+        let mut trait_infos = BTreeMap::new();
+        let mut trait_implementors: BTreeMap<Uuid, Vec<Uuid>> = BTreeMap::new();
+
+        for tr in &program.traits {
+            let trait_name = &tr.node.name.node;
+            if let Some(ti) = env.traits.get(trait_name.as_str()) {
+                let methods: Vec<(String, ResolvedSignature)> = ti
+                    .methods
+                    .iter()
+                    .map(|(name, sig)| {
+                        let is_fallible =
+                            env.is_trait_method_potentially_fallible(trait_name, name);
+                        (
+                            name.clone(),
+                            ResolvedSignature {
+                                param_types: sig.params.clone(),
+                                return_type: sig.return_type.clone(),
+                                is_fallible,
+                            },
+                        )
+                    })
+                    .collect();
+
+                // Find implementors by scanning classes
+                let mut implementors = Vec::new();
+                for (cls_name, cls_info) in &env.classes {
+                    if cls_info.impl_traits.iter().any(|t| t == trait_name) {
+                        if let Some(&uuid) = class_name_to_uuid.get(cls_name.as_str()) {
+                            implementors.push(uuid);
+                        }
+                    }
+                }
+                implementors.sort();
+
+                let trait_uuid = tr.node.id;
+                trait_implementors.insert(trait_uuid, implementors.clone());
+
+                trait_infos.insert(
+                    trait_uuid,
+                    ResolvedTraitInfo {
+                        methods,
+                        default_methods: ti.default_methods.clone(),
+                        implementors,
+                    },
+                );
+            }
+        }
+
+        // Build enum_infos
+        let mut enum_infos = BTreeMap::new();
+        for en in &program.enums {
+            let enum_name = &en.node.name.node;
+            if let Some(ei) = env.enums.get(enum_name.as_str()) {
+                let variants: Vec<ResolvedVariantInfo> = ei
+                    .variants
+                    .iter()
+                    .map(|(name, fields)| ResolvedVariantInfo {
+                        name: name.clone(),
+                        fields: fields
+                            .iter()
+                            .map(|(fname, fty)| ResolvedFieldInfo {
+                                name: fname.clone(),
+                                ty: fty.clone(),
+                                is_injected: false,
+                            })
+                            .collect(),
+                    })
+                    .collect();
+
+                enum_infos.insert(en.node.id, ResolvedEnumInfo { variants });
+            }
+        }
+
+        // Build error_infos
+        let mut error_infos = BTreeMap::new();
+        for err in &program.errors {
+            let err_name = &err.node.name.node;
+            if let Some(erri) = env.errors.get(err_name.as_str()) {
+                let fields: Vec<ResolvedFieldInfo> = erri
+                    .fields
+                    .iter()
+                    .map(|(name, ty)| ResolvedFieldInfo {
+                        name: name.clone(),
+                        ty: ty.clone(),
+                        is_injected: false,
+                    })
+                    .collect();
+
+                error_infos.insert(err.node.id, ResolvedErrorInfo { fields });
+            }
+        }
+
+        // Build di_order: map class names to UUIDs
+        let di_order: Vec<Uuid> = env
+            .di_order
+            .iter()
+            .filter_map(|name| class_name_to_uuid.get(name.as_str()).copied())
+            .collect();
+
         DerivedInfo {
             fn_error_sets,
             fn_signatures,
+            class_infos,
+            trait_infos,
+            enum_infos,
+            error_infos,
+            di_order,
+            trait_implementors,
         }
     }
 
@@ -179,5 +405,18 @@ mod tests {
     fn typeenv_key_module_prefixed() {
         // Module-prefixed functions keep their name as-is (prefix is part of the name)
         assert_eq!(typeenv_key("math.add", None), "math.add");
+    }
+
+    #[test]
+    fn default_has_empty_collections() {
+        let d = DerivedInfo::default();
+        assert!(d.fn_error_sets.is_empty());
+        assert!(d.fn_signatures.is_empty());
+        assert!(d.class_infos.is_empty());
+        assert!(d.trait_infos.is_empty());
+        assert!(d.enum_infos.is_empty());
+        assert!(d.error_infos.is_empty());
+        assert!(d.di_order.is_empty());
+        assert!(d.trait_implementors.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Extract richer type information from `TypeEnv` during `DerivedInfo::build()` and persist it in PLTO binaries keyed by UUID
- Previously only function error sets and signatures were stored — now class fields/methods/lifecycle, trait methods/implementors, enum variants, error fields, and DI ordering are all captured
- Surface enriched data through SDK query methods and MCP `inspect` tool output

## Changes
- **`src/derived.rs`** — 6 new structs (`ResolvedClassInfo`, `ResolvedFieldInfo`, `ResolvedTraitInfo`, `ResolvedEnumInfo`, `ResolvedVariantInfo`, `ResolvedErrorInfo`) + 6 new `DerivedInfo` fields with `#[serde(default)]` for backward compat
- **`sdk/src/module.rs`** — 6 new query methods: `class_info_of()`, `trait_info_of()`, `enum_info_of()`, `error_info_of()`, `di_order()`, `trait_implementors_of()`
- **`mcp/src/serialize.rs`** — Enriched all detail builders to include resolved type data
- **`mcp/src/server.rs`** — Pass `module` to all detail builders in `inspect_decl`
- **`src/binary.rs`**, **`sdk/src/lib.rs`** — Test helper + re-export updates

## Test plan
- [x] `cargo build` compiles cleanly (no new warnings)
- [x] `cargo test --lib` — all 282 unit tests pass
- [x] `cargo test` — full integration suite passes (0 failures)
- [x] PLTO schema version unchanged (v2) — `serde(default)` handles missing fields in old binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)