### PR TITLE
Add watch test mode for TDD workflow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,19 @@ enum WatchCommands {
         #[arg(long)]
         no_clear: bool,
     },
+    /// Watch and automatically re-run tests
+    Test {
+        /// The Pluto file to watch and test
+        file: PathBuf,
+
+        /// Don't clear terminal between runs
+        #[arg(long)]
+        no_clear: bool,
+
+        /// Disable test caching, run all tests
+        #[arg(long)]
+        no_cache: bool,
+    },
 }
 
 fn main() {
@@ -178,6 +191,13 @@ fn main() {
             WatchCommands::Run { file, no_clear } => {
                 if let Err(err) = plutoc::watch::watch_run(&file, stdlib, no_clear) {
                     eprintln!("Watch error: {err}");
+                    std::process::exit(1);
+                }
+            }
+            WatchCommands::Test { file, no_clear, no_cache } => {
+                let use_cache = !no_cache;
+                if let Err(err) = plutoc::watch::watch_test(&file, stdlib, no_clear, use_cache) {
+                    eprintln!("Watch test error: {err}");
                     std::process::exit(1);
                 }
             }


### PR DESCRIPTION
## Summary

Implement watch test mode to automatically detect file changes and rerun tests. This enables a TDD workflow with instant feedback on code changes.

## Features

- Automatic test rerunning on file changes
- Debouncing (100ms window after last change)
- Test status indicators (✓ TESTS PASSED / ✗ TESTS FAILED)
- Transitive import tracking (watches all imported modules)
- Continues watching even on compilation/test failures
- Optional `--no-clear` flag to preserve output between runs
- Optional `--no-cache` flag for test caching control

## Usage

```bash
plutoc watch test <file> [--stdlib <path>] [--no-clear] [--no-cache]
```

## Implementation

- **New function**: `watch_test()` in `src/watch.rs`
- **CLI integration**: Added `Test` variant to `WatchCommands`
- **Reuses infrastructure**: Leverages file watching, debouncing, and module resolution from watch run

## Testing

Manually tested:
- ✅ Initial test run detection
- ✅ File change detection and automatic test rerun
- ✅ Multiple test runs with different test counts
- ✅ Test status indicators showing pass/fail
- ✅ Continues watching after test failures
- ✅ `--no-clear` and `--no-cache` flags

## Phase 2 of Iterative Development Workstream

This is the second phase of the iterative development enhancements:
- Phase 1: Watch mode ✅ (merged)
- Phase 2: Watch test mode ✅ (this PR)
- Phase 3: REPL (next)
- Phase 4: Hot reload

See `docs/design/rfc-iterative-dev.md` for full roadmap.