### PR TITLE
Fix P1 #3: Generate unique test IDs for multiple test files

### DIFF
--- a/src/modules.rs
+++ b/src/modules.rs
@@ -51,7 +51,7 @@ fn load_and_parse(path: &Path, source_map: &mut SourceMap) -> Result<(Program, u
     })?;
     let file_id = source_map.add_file(path.to_path_buf(), source.clone());
     let tokens = lexer::lex(&source)?;
-    let mut parser = Parser::new(&tokens, &source);
+    let mut parser = Parser::new_with_path(&tokens, &source, path.display().to_string());
     let program = parser.parse_program()?;
     Ok((program, file_id))
 }
@@ -646,6 +646,7 @@ fn resolve_modules_inner(
             }
             root.stages.extend(program.stages);
             root.errors.extend(program.errors);
+            root.test_info.extend(program.test_info);
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes P1 #3: Test Runner Generates Duplicate IDs for Multiple Files

When multiple `.pluto` files in the same directory have test blocks, they previously generated duplicate test function IDs (`__test_0`, `__test_1`, etc.), causing linker errors due to duplicate symbols. This prevented organizing tests into multiple files in the same directory.

## Changes

### Parser (`src/parser/mod.rs`)
- Added `file_path: Option<String>` field to track source file path
- Created `new_with_path()` constructor to accept file path
- Added `test_id_prefix()` helper that generates 8-character hex hash from file path
- Updated test ID generation: `__test_{index}` → `__test_{hash}_{index}`
- Maintained backward compatibility with `file_path: None` for existing constructors

### Module System (`src/modules.rs`)
- Updated `load_and_parse()` to use `Parser::new_with_path()` with file path
- **Critical fix:** Added `root.test_info.extend(program.test_info)` to merge test_info from sibling files (was missing!)

### Tests (`tests/integration/testing.rs`)
- Added regression test `test_multiple_files_unique_test_ids()`
- Creates two sibling files with 2 tests each
- Verifies all 4 tests run successfully without duplicate symbol errors

### Documentation (`BUGS_AND_FEATURES.md`)
- Moved P1 #3 from "Active Bugs" to "Recently Fixed"
- Updated priority recommendations

## How It Works

Test IDs now include a unique prefix based on the file path hash:
- `file_a.pluto` → `__test_a1b2c3d4_0`, `__test_a1b2c3d4_1`
- `file_b.pluto` → `__test_5e6f7g8h_0`, `__test_5e6f7g8h_1`

This ensures uniqueness across all test files in a project.

## Testing

```bash
cargo test --test testing test_multiple_files_unique_test_ids
```

All 26 tests in `testing.rs` pass, including the new regression test.

## Related

- Bug report: `feedback/bugs/test-runner-duplicate-ids-multiple-files.md`
- Tracking: `BUGS_AND_FEATURES.md` P1 #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)