### PR TITLE
Update documentation for Phase 1 reflection

### DIFF
--- a/BUGS_AND_FEATURES.md
+++ b/BUGS_AND_FEATURES.md
@@ -269,7 +269,10 @@
   - [ ] Tests for migration
 
 #### Compile-Time Reflection (`docs/design/rfc-compile-time-reflection-and-encodings.md`)
-- **Phase 1:** `@generate` + basic intrinsics
+- **Phase 1:** ✅ `TypeInfo` trait + intrinsics for classes and enums
+  - Static trait methods: `TypeInfo::type_name<T>()`, `TypeInfo::kind<T>()`
+  - Metadata types: `FieldInfo`, `ClassInfo`, `VariantInfo`, `EnumInfo`, `TypeKind`
+  - Zero runtime overhead - all generated at compile time
 - **Phase 2:** Loop unrolling and compiler transforms
 - **Phase 3:** `JsonEncoding` implementation
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -286,22 +286,26 @@ See also: [ROADMAP.md](ROADMAP.md) for high-level goals and milestones
 
 ### Language Features
 
-#### 26. Compile-Time Reflection (Phase 1)
-- **Status:** 🔵 In Progress
+#### 26. Compile-Time Reflection (Phase 1) ✅
+- **Status:** ✅ Complete (PR #56)
 - **Effort:** L
 - **Impact:** High
 - **Description:** `TypeInfo::kind<T>()` for introspecting types at compile-time
 - **RFC:** `docs/design/rfc-compile-time-reflection-and-encodings.md`
 - **Use Cases:** JSON/Protobuf encodings, ORMs, serialization
-- **Current:** Static trait calls parser support merged (PR #41)
-- **Next:** Typeck + codegen + stdlib `reflection` module
+- **Implemented:**
+  - Static trait methods: `TypeInfo::type_name<T>()`, `TypeInfo::kind<T>()`
+  - Metadata types: `FieldInfo`, `ClassInfo`, `VariantInfo`, `EnumInfo`, `TypeKind`
+  - Automatic intrinsic generation for all classes and enums
+  - Zero runtime overhead - all generated at compile time
+- **Example:** `examples/reflection_demo.pluto`
 
 #### 27. Compile-Time Reflection (Phase 2)
-- **Status:** 🔴 Blocked
+- **Status:** 🟡 Ready
 - **Effort:** L
 - **Impact:** High
 - **Description:** Loop unrolling, compiler transforms for generated code
-- **Depends On:** Phase 1 (Feature #26)
+- **Depends On:** Phase 1 (Feature #26) ✅
 
 #### 28. Generic JsonEncoding (Phase 3)
 - **Status:** 🔴 Blocked

--- a/examples/README.md
+++ b/examples/README.md
@@ -273,3 +273,11 @@ Demonstrates the `std.regex` module for pattern matching: literal matching (`mat
 ```bash
 cargo run -- run examples/regex/main.pluto --stdlib stdlib
 ```
+
+## reflection_demo
+
+Demonstrates Phase 1 compile-time reflection with the `TypeInfo` trait: `TypeInfo::type_name<T>()` returns type names as strings, `TypeInfo::kind<T>()` provides detailed metadata (field names, types, offsets for classes; variant information for enums). Reflection intrinsics are generated at compile time with zero runtime overhead.
+
+```bash
+cargo run -- run examples/reflection_demo.pluto
+```


### PR DESCRIPTION
Mark reflection Phase 1 as complete in tracking docs and add example documentation.

Updates:
- BUGS_AND_FEATURES.md: Mark Phase 1 complete with implementation details
- FEATURES.md: Update Feature #26 to complete status, mark Phase 2 as ready
- examples/README.md: Add reflection_demo example

Follows up on PR #56.