### PR TITLE
Add unit tests for contracts and spawn modules

### DIFF
--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -247,3 +247,283 @@ fn desugar_expr(expr: &mut Expr, span: Span) {
         | Expr::NoneLit => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_span() -> Span {
+        Span::new(0, 0)
+    }
+
+    fn spanned<T>(node: T) -> Spanned<T> {
+        Spanned::new(node, dummy_span())
+    }
+
+    #[test]
+    fn spawn_desugars_function_call() {
+        let mut expr = Expr::Spawn {
+            call: Box::new(spanned(Expr::Call {
+                name: spanned("foo".to_string()),
+                args: vec![],
+                type_args: vec![],
+                target_id: None,
+            })),
+        };
+
+        desugar_expr(&mut expr, dummy_span());
+
+        // Check that spawn now contains a closure
+        match expr {
+            Expr::Spawn { call } => match &call.node {
+                Expr::Closure { params, body, return_type } => {
+                    assert_eq!(params.len(), 0);
+                    assert!(return_type.is_none());
+                    assert_eq!(body.node.stmts.len(), 1);
+                    // Check the closure body contains a return statement with the original call
+                    match &body.node.stmts[0].node {
+                        Stmt::Return(Some(ret_expr)) => match &ret_expr.node {
+                            Expr::Call { name, .. } => {
+                                assert_eq!(name.node, "foo");
+                            }
+                            _ => panic!("Expected call in return statement"),
+                        },
+                        _ => panic!("Expected return statement in closure body"),
+                    }
+                }
+                _ => panic!("Expected closure after desugaring"),
+            },
+            _ => panic!("Expected spawn expression"),
+        }
+    }
+
+    #[test]
+    fn spawn_desugars_method_call() {
+        let mut expr = Expr::Spawn {
+            call: Box::new(spanned(Expr::MethodCall {
+                object: Box::new(spanned(Expr::Ident("obj".to_string()))),
+                method: spanned("bar".to_string()),
+                args: vec![],
+            })),
+        };
+
+        desugar_expr(&mut expr, dummy_span());
+
+        // Check that spawn now contains a closure
+        match expr {
+            Expr::Spawn { call } => match &call.node {
+                Expr::Closure { params, body, return_type } => {
+                    assert_eq!(params.len(), 0);
+                    assert!(return_type.is_none());
+                    assert_eq!(body.node.stmts.len(), 1);
+                    match &body.node.stmts[0].node {
+                        Stmt::Return(Some(ret_expr)) => match &ret_expr.node {
+                            Expr::MethodCall { method, .. } => {
+                                assert_eq!(method.node, "bar");
+                            }
+                            _ => panic!("Expected method call in return statement"),
+                        },
+                        _ => panic!("Expected return statement in closure body"),
+                    }
+                }
+                _ => panic!("Expected closure after desugaring"),
+            },
+            _ => panic!("Expected spawn expression"),
+        }
+    }
+
+    #[test]
+    fn spawn_preserves_function_call_args() {
+        let mut expr = Expr::Spawn {
+            call: Box::new(spanned(Expr::Call {
+                name: spanned("foo".to_string()),
+                args: vec![
+                    spanned(Expr::IntLit(42)),
+                    spanned(Expr::Ident("x".to_string())),
+                ],
+                type_args: vec![],
+                target_id: None,
+            })),
+        };
+
+        desugar_expr(&mut expr, dummy_span());
+
+        match expr {
+            Expr::Spawn { call } => match &call.node {
+                Expr::Closure { body, .. } => match &body.node.stmts[0].node {
+                    Stmt::Return(Some(ret_expr)) => match &ret_expr.node {
+                        Expr::Call { name, args, .. } => {
+                            assert_eq!(name.node, "foo");
+                            assert_eq!(args.len(), 2);
+                            assert!(matches!(args[0].node, Expr::IntLit(42)));
+                            assert!(matches!(args[1].node, Expr::Ident(_)));
+                        }
+                        _ => panic!("Expected call"),
+                    },
+                    _ => panic!("Expected return"),
+                },
+                _ => panic!("Expected closure"),
+            },
+            _ => panic!("Expected spawn"),
+        }
+    }
+
+    #[test]
+    fn desugar_recurses_into_nested_expressions() {
+        // Test that desugaring recurses properly into nested structures
+        let mut expr = Expr::BinOp {
+            op: BinOp::Add,
+            lhs: Box::new(spanned(Expr::Spawn {
+                call: Box::new(spanned(Expr::Call {
+                    name: spanned("foo".to_string()),
+                    args: vec![],
+                    type_args: vec![],
+                    target_id: None,
+                })),
+            })),
+            rhs: Box::new(spanned(Expr::IntLit(1))),
+        };
+
+        desugar_expr(&mut expr, dummy_span());
+
+        // Check that the spawn in the lhs was desugared
+        match expr {
+            Expr::BinOp { lhs, .. } => match &lhs.node {
+                Expr::Spawn { call } => match &call.node {
+                    Expr::Closure { .. } => {
+                        // Success - spawn was desugared
+                    }
+                    _ => panic!("Spawn should contain closure after desugaring"),
+                },
+                _ => panic!("Expected spawn in lhs"),
+            },
+            _ => panic!("Expected binop"),
+        }
+    }
+
+    #[test]
+    fn desugar_handles_array_literals() {
+        let mut expr = Expr::ArrayLit {
+            elements: vec![
+                spanned(Expr::IntLit(1)),
+                spanned(Expr::Spawn {
+                    call: Box::new(spanned(Expr::Call {
+                        name: spanned("foo".to_string()),
+                        args: vec![],
+                        type_args: vec![],
+                        target_id: None,
+                    })),
+                }),
+            ],
+        };
+
+        desugar_expr(&mut expr, dummy_span());
+
+        match expr {
+            Expr::ArrayLit { elements } => {
+                assert_eq!(elements.len(), 2);
+                // Second element should be desugared spawn
+                match &elements[1].node {
+                    Expr::Spawn { call } => match &call.node {
+                        Expr::Closure { .. } => {
+                            // Success
+                        }
+                        _ => panic!("Spawn should contain closure"),
+                    },
+                    _ => panic!("Expected spawn in array"),
+                }
+            }
+            _ => panic!("Expected array literal"),
+        }
+    }
+
+    #[test]
+    fn desugar_stmt_let_binding() {
+        let mut stmt = Stmt::Let {
+            name: spanned("x".to_string()),
+            ty: None,
+            is_mut: false,
+            value: spanned(Expr::Spawn {
+                call: Box::new(spanned(Expr::Call {
+                    name: spanned("foo".to_string()),
+                    args: vec![],
+                    type_args: vec![],
+                    target_id: None,
+                })),
+            }),
+        };
+
+        desugar_stmt(&mut stmt);
+
+        match stmt {
+            Stmt::Let { value, .. } => match &value.node {
+                Expr::Spawn { call } => match &call.node {
+                    Expr::Closure { .. } => {
+                        // Success
+                    }
+                    _ => panic!("Spawn should be desugared"),
+                },
+                _ => panic!("Expected spawn"),
+            },
+            _ => panic!("Expected let statement"),
+        }
+    }
+
+    #[test]
+    fn desugar_block_multiple_statements() {
+        let mut block = Block {
+            stmts: vec![
+                spanned(Stmt::Let {
+                    name: spanned("x".to_string()),
+                    ty: None,
+                    is_mut: false,
+                    value: spanned(Expr::Spawn {
+                        call: Box::new(spanned(Expr::Call {
+                            name: spanned("foo".to_string()),
+                            args: vec![],
+                            type_args: vec![],
+                            target_id: None,
+                        })),
+                    }),
+                }),
+                spanned(Stmt::Return(Some(spanned(Expr::Spawn {
+                    call: Box::new(spanned(Expr::Call {
+                        name: spanned("bar".to_string()),
+                        args: vec![],
+                        type_args: vec![],
+                        target_id: None,
+                    })),
+                })))),
+            ],
+        };
+
+        desugar_block(&mut block);
+
+        // Both statements should have their spawns desugared
+        assert_eq!(block.stmts.len(), 2);
+
+        // Check first statement
+        match &block.stmts[0].node {
+            Stmt::Let { value, .. } => match &value.node {
+                Expr::Spawn { call } => match &call.node {
+                    Expr::Closure { .. } => {}
+                    _ => panic!("First spawn should be desugared"),
+                },
+                _ => panic!("Expected spawn in let"),
+            },
+            _ => panic!("Expected let statement"),
+        }
+
+        // Check second statement
+        match &block.stmts[1].node {
+            Stmt::Return(Some(ret_expr)) => match &ret_expr.node {
+                Expr::Spawn { call } => match &call.node {
+                    Expr::Closure { .. } => {}
+                    _ => panic!("Second spawn should be desugared"),
+                },
+                _ => panic!("Expected spawn in return"),
+            },
+            _ => panic!("Expected return statement"),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds 35 new unit tests to provide focused validation of core compiler transformation logic.

## Changes

### Contract Validation Tests (28 tests)
- Tests for `validate_decidable_fragment()` function in `src/contracts.rs`
- Validates allowed expressions: literals, operators, field access, `.len()`
- Tests rejection of disallowed expressions: closures, spawn, casts, function calls
- Tests `old()` behavior in different contract contexts

### Spawn Desugaring Tests (7 tests)
- Tests for spawn desugaring logic in `src/spawn.rs`
- Validates transformation of `spawn func(args)` into closure form
- Tests recursion into nested expressions, statements, and blocks
- Verifies argument preservation and proper desugaring

## Test Results
- **Unit tests**: 350 passed (up from 315)
- **Integration tests**: All pass except 1 pre-existing failure unrelated to these changes
- **Performance**: Unit tests run in 0.02s

## Benefits
- Faster feedback during development (unit tests vs full integration tests)
- Better coverage of edge cases in contract validation
- Clear documentation of expected behavior through tests

## Note
The `trait_contract_self_field_rejected` integration test failure exists on master and is unrelated to these changes.