### PR TITLE
Fix missing f-prefix in string interpolation test

### DIFF
--- a/tests/integration/control_flow_extended.rs
+++ b/tests/integration/control_flow_extended.rs
@@ -620,7 +620,7 @@ fn if_expr_as_method_object() {
 fn if_expr_in_string_interpolation() {
     let stdout = compile_and_run_stdout(r#"
         fn main() {
-            let msg = "result: {if true { 42 } else { 99 }}"
+            let msg = f"result: {if true { 42 } else { 99 }}"
             print(msg)
         }
     "#);


### PR DESCRIPTION
## Summary
- Add missing `f` prefix to `if_expr_in_string_interpolation` test — it was using bare `"result: {if true { 42 } else { 99 }}"` instead of `f"..."`, which fails now that the f-prefix is required for interpolation

## Test plan
- [ ] `cargo nextest run -E 'test(if_expr_in_string_interpolation)'` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)