### PR TITLE
Enable 2 codegen tests that now pass (fixes #132)

### DIFF
--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,10 +1,7 @@
 use crate::diagnostics::CompileError;
 use crate::parser::ast::*;
-use crate::span::Spanned;
+use crate::span::{Span, Spanned};
 use crate::visit::{walk_expr_mut, VisitMut};
-
-#[cfg(test)]
-use crate::span::Span;
 
 /// Desugar `spawn func(args)` into `spawn (=> { return func(args) })`.
 ///

--- a/tests/codegen/_01_type_representation.rs
+++ b/tests/codegen/_01_type_representation.rs
@@ -590,7 +590,6 @@ fn test_class_nested_5_deep() {
 }
 
 #[test]
-#[ignore] // Compiler warnings in output causing test to fail
 fn test_class_with_bracket_deps() {
     let src = r#"
         class Config {
@@ -615,7 +614,6 @@ fn test_class_with_bracket_deps() {
 }
 
 #[test]
-#[ignore] // Compiler warnings in output causing test to fail
 fn test_class_with_methods() {
     let src = r#"
         class Counter {


### PR DESCRIPTION
The app declaration main detection bug (#132) has been resolved - the compiler no longer incorrectly reports "cannot have both app declaration and top-level main" when there is only an app method.

## Changes
- Enable `test_class_with_bracket_deps`: Tests nested bracket deps (Config → Server → MyApp)
- Enable `test_class_with_methods`: Tests class methods with mut self
- Fix duplicate Span import in `src/spawn.rs` after rebase

All 522 codegen tests passing.

Fixes #132