### PR TITLE
Add MCP server documentation and best practices

### DIFF
--- a/docs/mcp-best-practices.md
+++ b/docs/mcp-best-practices.md
@@ -1,0 +1,289 @@
+# MCP Best Practices
+
+Guidelines for AI agents and developers working with the Pluto MCP server. Following these practices leads to faster, more reliable, and safer editing workflows.
+
+---
+
+## 1. Project Initialization
+
+**Always start with `load_project`**, not `load_module`.
+
+`load_project` does three things that `load_module` doesn't:
+
+1. **Loads all `.pluto` files** in the directory tree, so cross-module searches work immediately
+2. **Builds the dependency graph**, detecting circular imports before you hit them during compilation
+3. **Establishes the project root** for path safety validation — write tools are blocked without it
+
+```
+// Good: loads everything, enables writes, enables cross-module queries
+load_project({ path: "/path/to/project", stdlib: "/path/to/pluto/stdlib" })
+
+// Bad: only loads one file, write tools will fail (no project root)
+load_module({ path: "/path/to/project/main.pluto" })
+```
+
+**Pass the stdlib path** if your project uses any `std.*` imports. Without it, `check`, `compile`, and `run` will fail on imports like `import std.collections`.
+
+---
+
+## 2. Explore Before Editing
+
+**Read the code before changing it.** The MCP server provides structured inspection tools that are faster and more reliable than reading raw source.
+
+**Recommended exploration flow:**
+
+```
+1. list_modules           → See what files exist
+2. list_declarations      → See what's in each file
+3. get_declaration        → Deep-inspect specific items
+4. callers_of / usages_of → Understand usage patterns
+5. call_graph             → Trace execution paths
+```
+
+**Use `find_declaration` for cross-module search.** If you know a function name but not which file it's in, `find_declaration` searches all loaded modules.
+
+**Use `get_declaration` by UUID, not name.** Names can be ambiguous (a function and a class can share a name). UUIDs are unique. After the first lookup by name, use the returned UUID for subsequent queries.
+
+**Use `usages_of` instead of individual xref tools.** `usages_of` combines `callers_of`, `constructors_of`, `enum_usages_of`, and `raise_sites_of` into a single call. Use the individual tools only when you need to filter by usage kind.
+
+---
+
+## 3. Incremental Validation
+
+**Check after every edit**, not just at the end.
+
+```
+add_declaration(...)   → check(...)   → fix errors
+replace_declaration(...) → check(...) → fix errors
+delete_declaration(...)  → check(...) → fix dangling refs
+```
+
+Type errors compound. A bad type change in one declaration can cascade into dozens of errors elsewhere. Catching it immediately means fixing one thing instead of untangling ten.
+
+**Use `check` for validation, not `compile`.** `check` runs the type checker without generating a binary — it's faster and gives the same diagnostics. Only use `compile` when you actually need the binary.
+
+**`check` always reads from disk.** Unlike inspection tools (which use the cached AST), `check` re-reads the file from disk. Since write tools write to disk and update the cache simultaneously, this is seamless — but be aware that `check` will pick up any external edits too.
+
+---
+
+## 4. Choosing the Right Write Tool
+
+The MCP server has six write tools, each for a specific operation. Using the right one preserves UUIDs and avoids unnecessary churn.
+
+| Task | Tool | UUID Behavior |
+|------|------|---------------|
+| Add a new function/class/enum/etc. | `add_declaration` | New UUID assigned |
+| Modify a function body or signature | `replace_declaration` | UUID preserved |
+| Remove a declaration | `delete_declaration` | Reports dangling refs |
+| Change a declaration's name | `rename_declaration` | UUID preserved, intra-file refs updated |
+| Add a method to a class | `add_method` | New UUID for method, class UUID unchanged |
+| Add a field to a class | `add_field` | New UUID for field, class UUID unchanged |
+
+**Prefer `replace_declaration` over delete + add.** Replacing preserves the UUID, which keeps cross-references, call graphs, and derived analysis data stable. Delete + add generates a new UUID and breaks any external references.
+
+**Prefer `add_method` / `add_field` over `replace_declaration` for the whole class.** Adding a method or field is surgical — it touches only the new addition. Replacing the entire class re-parses everything and risks formatting changes.
+
+**Always check `dangling_refs` after `delete_declaration`.** The response tells you exactly which declarations in the same file reference the deleted one. Fix these before moving on.
+
+---
+
+## 5. File Watching and Staleness
+
+**Use `module_status` to detect external changes.** If another developer (or another tool) modifies a `.pluto` file while your session is active, the in-memory cache becomes stale. `module_status` compares file modification times against load times to detect this.
+
+```
+module_status()
+// Response: [{ path: "...", is_stale: true, loaded_at: 1707933600 }]
+```
+
+**Use `reload_module` to refresh stale modules.** After detecting staleness, reload the specific module. You don't need to reload the entire project.
+
+```
+// Good: targeted reload
+reload_module({ path: "/path/to/changed_file.pluto" })
+
+// Overkill: reloads everything (slow for large projects)
+load_project({ path: "/path/to/project" })
+```
+
+**Write tools auto-refresh the cache.** When you use `add_declaration`, `replace_declaration`, etc., the MCP server writes to disk and updates the cache atomically. You don't need to call `reload_module` after your own writes.
+
+**Check staleness before complex operations.** Before a multi-step refactor, run `module_status` to make sure you're working with current data. Editing a stale module risks conflicting with external changes.
+
+---
+
+## 6. Documentation-First Development
+
+**Use `docs` and `stdlib_docs` before writing code.** The MCP server embeds the full Pluto language reference and stdlib API documentation. Query it to get correct syntax, available types, and function signatures.
+
+```
+// Check how errors work before implementing error handling
+docs({ topic: "errors" })
+
+// Check what std.collections provides before importing it
+stdlib_docs({ module: "collections" })
+```
+
+**Available language topics:** `types`, `operators`, `statements`, `declarations`, `strings`, `errors`, `closures`, `generics`, `modules`, `contracts`, `concurrency`, `gotchas`
+
+**Available stdlib modules:** `strings`, `math`, `fs`, `json`, `http`, `net`, `socket`, `collections`, `io`, `random`, `time`
+
+**Check the `gotchas` topic.** It covers common pitfalls like newline sensitivity, empty struct literals, and generic syntax ambiguities.
+
+---
+
+## 7. Cross-Module Workflow
+
+When making changes that affect multiple files, follow this order:
+
+### Adding a new declaration used by other files
+
+```
+1. add_declaration in the defining module  → check
+2. Verify it compiles: check({ path: "defining_module.pluto" })
+3. Update importing modules: replace_declaration in each caller → check each
+4. Final validation: run or test on the entry point
+```
+
+### Renaming a declaration
+
+`rename_declaration` updates references within the same file but **not** across modules. Handle cross-module updates manually:
+
+```
+1. usages_of({ uuid: "..." })  → find all cross-module callers
+2. rename_declaration in the defining file
+3. replace_declaration in each calling file to use the new name
+4. check each modified file
+```
+
+### Deleting a declaration
+
+```
+1. usages_of({ uuid: "..." })  → find all usages
+2. Update or remove all cross-module callers first
+3. delete_declaration  → check dangling_refs for intra-file issues
+4. check the file
+```
+
+**Always update callers before deleting the callee.** If you delete first, the callers will have dangling references and `check` will report errors you already knew about.
+
+---
+
+## 8. Safety Practices
+
+### Path Safety
+
+**All write operations are sandboxed** within the project root established by `load_project`. The server validates every write path to prevent:
+
+- Writing outside the project directory
+- Directory traversal attacks (`../../../etc/passwd`)
+- Symlink escapes
+
+If a write tool returns a path safety error, it means the target path resolves outside the project root. This is a hard block — you cannot bypass it.
+
+### UUID Stability
+
+**UUIDs are the stable identity of declarations.** They survive renames, body changes, and reformatting. Treat UUIDs as the primary key for referencing declarations across tools.
+
+UUIDs are lost when:
+- A declaration is deleted and re-added (new UUID assigned)
+- A `.pluto` file is recreated from scratch (all UUIDs regenerated)
+- The file is synced from `.pt` without UUID hints
+
+Use `pretty_print` with `include_uuid_hints: true` to preserve UUIDs in text format:
+
+```
+pretty_print({ path: "...", include_uuid_hints: true })
+// Output:
+// // @uuid: a1b2c3d4-...
+// fn add(a: int, b: int) int {
+//     return a + b
+// }
+```
+
+### Source Preservation
+
+**Write tools modify source text on disk.** They don't just update the AST — they write the actual `.pluto` source file. This means:
+
+- Formatting may change (the pretty-printer normalizes whitespace)
+- Comments outside declarations may be affected
+- The file is always valid Pluto after a write (parsed before writing)
+
+---
+
+## 9. Performance
+
+### Minimize Redundant Loads
+
+- **Don't call `load_project` repeatedly.** Once loaded, modules stay cached. Use `reload_module` for individual refreshes.
+- **Don't call `load_module` on files already loaded by `load_project`.** Check `list_modules` first.
+
+### Use Targeted Queries
+
+- **Use `list_declarations` with `kind` filter** instead of listing everything and filtering client-side.
+- **Use `callers_of` instead of `call_graph`** when you only need direct callers (depth 1).
+- **Use `get_source` with byte ranges** when you need a specific section of a large file, not the whole thing.
+
+### Batch Logically
+
+If you need to make multiple related changes to the same file, consider:
+- Using `replace_declaration` for each changed declaration (rather than replacing the whole file)
+- Running `check` once after all changes, not after each one, if the changes are interdependent
+- Using `add_declaration` with multiple declarations in a single source string:
+
+```
+add_declaration({
+  path: "...",
+  source: "fn foo() int { return 1 }\n\nfn bar() int { return 2 }"
+})
+// Both declarations added in one call
+```
+
+### Call Graph Depth
+
+- Default depth is 5, maximum is 20
+- Start with the default. Only increase depth if you need deeper analysis
+- Deep call graphs on large projects can be slow — use `direction: "callers"` to trace upward from a specific function rather than expanding the full callees tree
+
+---
+
+## 10. Common Anti-Patterns
+
+### Writing raw source files directly
+
+Don't bypass the MCP server by writing `.pluto` files directly (e.g., via filesystem tools). The MCP server:
+- Parses the source to validate it's correct Pluto
+- Assigns UUIDs to new declarations
+- Updates the module cache
+- Validates path safety
+
+Writing directly skips all of these. If you must write directly, call `reload_module` afterward.
+
+### Ignoring check results
+
+Don't assume a write succeeded just because the tool returned success. The write tool confirms the source was valid Pluto and was written to disk, but it doesn't type-check. A syntactically valid declaration can still have type errors. Always `check` after writes.
+
+### Over-relying on names instead of UUIDs
+
+Names can be ambiguous. Multiple declarations can have the same name (a function `Point` and a class `Point`). After the first lookup, switch to UUIDs:
+
+```
+// First lookup: by name
+find_declaration({ name: "Point" })
+// Returns: [{ uuid: "abc...", kind: "function" }, { uuid: "def...", kind: "class" }]
+
+// Subsequent lookups: by UUID
+get_declaration({ path: "...", uuid: "def..." })
+```
+
+### Loading the whole project to check one file
+
+`check` reads from disk and doesn't require the file to be loaded. If you just need to validate a single file, you can `check` it directly without loading the entire project (as long as you don't need write tools).
+
+### Forgetting stdlib path
+
+If compilation fails with "unknown module" errors for `std.*` imports, you forgot to pass the `stdlib` parameter. Pass it to `load_project`, `check`, `compile`, `run`, and `test`:
+
+```
+check({ path: "...", stdlib: "/path/to/pluto/stdlib" })
+```

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,789 @@
+# Pluto MCP Server
+
+The Pluto MCP (Model Context Protocol) server enables AI agents like Claude Code to work with Pluto projects natively. Instead of reading and writing raw text, the agent uses structured tools to explore, modify, compile, and test Pluto code.
+
+## Setup
+
+### Building
+
+```bash
+cd mcp/
+cargo build --release
+```
+
+The binary is `target/release/pluto-mcp`.
+
+### Claude Code Configuration
+
+Add to your Claude Code MCP settings (`~/.claude/mcp-servers.json` or project-level `.claude/mcp-servers.json`):
+
+```json
+{
+  "mcpServers": {
+    "pluto": {
+      "command": "/path/to/pluto-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+The server communicates over stdio (stdin/stdout) using the MCP protocol.
+
+### Stdlib Path
+
+If your project uses standard library modules (`import std.fs`, `import std.collections`, etc.), you need to provide the stdlib path when loading projects or compiling. The stdlib lives at `stdlib/` in the Pluto repository.
+
+---
+
+## Quick Start
+
+A typical workflow looks like this:
+
+```
+1. load_project    → Load all .pluto files in the project
+2. list_modules    → See what modules are loaded
+3. find_declaration / get_declaration → Explore the code
+4. add_declaration / replace_declaration → Make changes
+5. check           → Validate with the type checker
+6. run / test      → Execute and verify
+```
+
+---
+
+## Tools Reference
+
+### Project & Module Loading
+
+#### `load_project`
+
+Scan a project directory and load all `.pluto` source files. This is the recommended way to start a session — it loads everything, builds the dependency graph, detects circular imports, and sets up the project root for path safety.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Absolute path to the project root directory |
+| `stdlib` | string | no | Path to stdlib root (needed for `std.*` imports) |
+
+**Returns:** `ProjectSummary`
+```json
+{
+  "project_root": "/path/to/project",
+  "files_found": 5,
+  "files_loaded": 5,
+  "files_failed": 0,
+  "modules": [
+    { "path": "/path/to/main.pluto", "declarations": 3 },
+    { "path": "/path/to/math.pluto", "declarations": 5 }
+  ],
+  "errors": [],
+  "dependency_graph": {
+    "module_count": 2,
+    "has_circular_imports": false,
+    "modules": [
+      { "path": "/path/to/main.pluto", "name": "main", "imports": ["math"] }
+    ]
+  }
+}
+```
+
+#### `load_module`
+
+Load a single `.pluto` source file or PLTO binary file. Use `load_project` instead when working with multi-file projects.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Absolute path to a `.pluto` source or binary file |
+| `stdlib` | string | no | Path to stdlib root |
+
+**Returns:** `ModuleSummary`
+```json
+{
+  "path": "/path/to/file.pluto",
+  "summary": {
+    "functions": 3,
+    "classes": 1,
+    "enums": 0,
+    "traits": 1,
+    "errors": 0,
+    "app": 0
+  },
+  "declarations": [
+    { "name": "add", "uuid": "a1b2c3d4-...", "kind": "function" },
+    { "name": "Point", "uuid": "e5f6a7b8-...", "kind": "class" }
+  ]
+}
+```
+
+#### `list_modules`
+
+List all currently loaded modules with declaration counts.
+
+**Parameters:** None
+
+**Returns:** Array of `ModuleListEntry`
+```json
+[
+  {
+    "path": "/path/to/main.pluto",
+    "summary": { "functions": 2, "classes": 0, "enums": 1, "traits": 0, "errors": 0, "app": 1 }
+  }
+]
+```
+
+---
+
+### Querying Declarations
+
+#### `list_declarations`
+
+List all declarations in a loaded module, optionally filtered by kind.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the loaded module |
+| `kind` | string | no | Filter: `function`, `class`, `enum`, `trait`, `error`, `app` |
+
+**Returns:** Array of `DeclSummary` (name, uuid, kind)
+
+#### `get_declaration`
+
+Deep-inspect a specific declaration. Returns full details including parameters, fields, methods, error sets, contracts, and pretty-printed source.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the loaded module |
+| `uuid` | string | no | UUID of the declaration |
+| `name` | string | no | Name of the declaration (may be ambiguous) |
+
+At least one of `uuid` or `name` must be provided. If `name` matches multiple declarations, the server returns a disambiguation list.
+
+**Returns:** One of `FunctionDetail`, `ClassDetail`, `EnumDetail`, `TraitDetail`, `ErrorDeclDetail`, or `AppDetail` depending on the declaration kind.
+
+**Example (function):**
+```json
+{
+  "name": "add",
+  "uuid": "a1b2c3d4-...",
+  "kind": "function",
+  "params": [
+    { "name": "a", "type": "int", "is_mut": false },
+    { "name": "b", "type": "int", "is_mut": false }
+  ],
+  "return_type": "int",
+  "is_fallible": false,
+  "error_set": [],
+  "signature": {
+    "param_types": ["Int"],
+    "return_type": "Int",
+    "is_fallible": false
+  },
+  "source": "fn add(a: int, b: int) int {\n    return a + b\n}\n"
+}
+```
+
+**Example (class):**
+```json
+{
+  "name": "Point",
+  "uuid": "e5f6a7b8-...",
+  "kind": "class",
+  "fields": [
+    { "name": "x", "type": "float", "uuid": "..." },
+    { "name": "y", "type": "float", "uuid": "..." }
+  ],
+  "methods": [
+    { "name": "distance", "uuid": "..." }
+  ],
+  "bracket_deps": [],
+  "impl_traits": ["Printable"],
+  "invariant_count": 0,
+  "resolved_fields": [
+    { "name": "x", "type": "Float", "is_injected": false }
+  ],
+  "lifecycle": "Transient",
+  "source": "class Point {\n    x: float\n    y: float\n    ...\n}\n"
+}
+```
+
+#### `find_declaration`
+
+Search for a declaration by name across all loaded modules.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | string | yes | Name to search for |
+| `kind` | string | no | Filter: `function`, `class`, `enum`, `trait`, `error`, `app` |
+
+**Returns:** Array of `CrossModuleMatch`
+```json
+[
+  {
+    "module_path": "/path/to/math.pluto",
+    "uuid": "a1b2c3d4-...",
+    "name": "add",
+    "kind": "function"
+  }
+]
+```
+
+#### `get_source`
+
+Get raw source text from a loaded module, optionally at a specific byte range.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the loaded module |
+| `start` | int | no | Start byte offset (default: 0) |
+| `end` | int | no | End byte offset (default: end of file) |
+
+**Returns:** Raw source text as string.
+
+#### `error_set`
+
+Get error handling information for a specific function.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the loaded module |
+| `uuid` | string | yes | UUID of the function |
+
+**Returns:**
+```json
+{
+  "function_name": "parse_config",
+  "is_fallible": true,
+  "error_set": [
+    { "name": "FileError", "uuid": "..." },
+    { "name": "ParseError", "uuid": "..." }
+  ]
+}
+```
+
+---
+
+### Cross-References
+
+All cross-reference tools search across **all loaded modules**, not just a single file. Load your project with `load_project` first.
+
+#### `callers_of`
+
+Find all call sites that invoke a function.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `uuid` | string | yes | UUID of the function |
+
+**Returns:** Array of `CrossModuleXrefSiteInfo`
+```json
+[
+  {
+    "module_path": "/path/to/main.pluto",
+    "function_name": "process",
+    "function_uuid": "...",
+    "span": { "start": 142, "end": 156, "start_line": 8, "start_col": 5, "end_line": 8, "end_col": 19 }
+  }
+]
+```
+
+#### `constructors_of`
+
+Find all sites where a class is constructed (struct literal syntax).
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `uuid` | string | yes | UUID of the class |
+
+**Returns:** Array of `CrossModuleXrefSiteInfo`
+
+#### `enum_usages_of`
+
+Find all sites where an enum or its variants are referenced.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `uuid` | string | yes | UUID of the enum |
+
+**Returns:** Array of `CrossModuleXrefSiteInfo`
+
+#### `raise_sites_of`
+
+Find all sites where an error type is raised.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `uuid` | string | yes | UUID of the error declaration |
+
+**Returns:** Array of `CrossModuleXrefSiteInfo`
+
+#### `usages_of`
+
+Unified cross-reference search. Returns all usages of a declaration in a single query: calls, constructions, enum variant references, and raise sites.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `uuid` | string | yes | UUID of the declaration |
+
+**Returns:** Array of `UnifiedXrefInfo`
+```json
+[
+  {
+    "module_path": "/path/to/main.pluto",
+    "usage_kind": "call",
+    "function_name": "process",
+    "function_uuid": "...",
+    "span": { "start": 142, "end": 156 }
+  },
+  {
+    "module_path": "/path/to/utils.pluto",
+    "usage_kind": "construct",
+    "function_name": "create_default",
+    "function_uuid": "...",
+    "span": { "start": 88, "end": 120 }
+  }
+]
+```
+
+The `usage_kind` field is one of: `"call"`, `"construct"`, `"enum_variant"`, `"raise"`.
+
+#### `call_graph`
+
+Build a call graph starting from a function, traversing across module boundaries.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `uuid` | string | yes | UUID of the root function |
+| `max_depth` | int | no | Maximum traversal depth (default: 5, max: 20) |
+| `direction` | string | no | `"callers"` or `"callees"` (default: `"callees"`) |
+
+**Returns:**
+```json
+{
+  "root_uuid": "...",
+  "root_name": "process_request",
+  "direction": "callers",
+  "max_depth": 5,
+  "nodes": [
+    {
+      "uuid": "...",
+      "name": "process_request",
+      "module_path": "/path/to/handlers.pluto",
+      "depth": 0,
+      "children": [
+        {
+          "uuid": "...",
+          "name": "handle_api",
+          "module_path": "/path/to/api.pluto",
+          "is_cycle": null
+        }
+      ]
+    }
+  ]
+}
+```
+
+Cycle detection is built in — recursive or mutually-recursive calls are flagged with `"is_cycle": true` instead of recursing infinitely.
+
+---
+
+### Write Tools
+
+Write tools modify source files directly on disk. All paths are validated against the project root (set by `load_project`) to prevent directory traversal. The in-memory module cache is updated to reflect changes.
+
+#### `add_declaration`
+
+Add one or more top-level declarations to a file. Creates the file if it doesn't exist.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path to the `.pluto` source file |
+| `source` | string | yes | Pluto source code for the declaration(s) |
+
+**Returns:** Array of `AddDeclResult`
+```json
+[
+  { "uuid": "newly-generated-uuid", "name": "my_function", "kind": "function" }
+]
+```
+
+**Example source:**
+```
+fn greet(name: string) string {
+    return "hello {name}"
+}
+```
+
+#### `replace_declaration`
+
+Replace an existing declaration by name. The replacement must be the same kind (e.g., a function can only be replaced with a function). The UUID is preserved.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the `.pluto` source file |
+| `name` | string | yes | Name of the declaration to replace |
+| `source` | string | yes | Pluto source code for the replacement |
+
+**Returns:** `ReplaceDeclResult`
+```json
+{ "uuid": "preserved-uuid", "name": "greet", "kind": "function" }
+```
+
+#### `delete_declaration`
+
+Delete a declaration by name. Reports any dangling references that result from the deletion.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the `.pluto` source file |
+| `name` | string | yes | Name of the declaration to delete |
+
+**Returns:** `DeleteDeclResult`
+```json
+{
+  "deleted_source": "fn old_func() { ... }",
+  "dangling_refs": [
+    { "kind": "call", "name": "old_func", "span": { "start": 200, "end": 212 } }
+  ]
+}
+```
+
+Always check `dangling_refs` — if non-empty, other declarations in the file reference the deleted one and need to be updated.
+
+#### `rename_declaration`
+
+Rename a declaration. Updates all intra-file references automatically.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the `.pluto` source file |
+| `old_name` | string | yes | Current name |
+| `new_name` | string | yes | New name |
+
+**Returns:** `RenameDeclResult`
+```json
+{ "old_name": "calculate", "new_name": "compute", "uuid": "preserved-uuid" }
+```
+
+Note: Cross-module references (in other files) are **not** automatically updated. Use `callers_of` to find external callers and update them manually.
+
+#### `add_method`
+
+Add a method to an existing class.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the `.pluto` source file |
+| `class_name` | string | yes | Name of the class |
+| `source` | string | yes | Method source (must include `self` or `mut self` parameter) |
+
+**Returns:** `AddMethodResult`
+```json
+{ "uuid": "new-method-uuid", "name": "area" }
+```
+
+**Example source:**
+```
+fn area(self) float {
+    return self.width * self.height
+}
+```
+
+#### `add_field`
+
+Add a field to an existing class.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the `.pluto` source file |
+| `class_name` | string | yes | Name of the class |
+| `field_name` | string | yes | Name of the new field |
+| `field_type` | string | yes | Type string (e.g., `"int"`, `"string"`, `"[float]"`) |
+
+**Returns:** `AddFieldResult`
+```json
+{ "uuid": "new-field-uuid" }
+```
+
+---
+
+### Compile & Execute
+
+#### `check`
+
+Type-check a source file without producing a binary. Returns structured diagnostics.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Absolute path to the `.pluto` source file |
+| `stdlib` | string | no | Path to stdlib root |
+
+**Returns:** `CheckResult`
+```json
+{
+  "success": false,
+  "path": "/path/to/file.pluto",
+  "errors": [
+    {
+      "severity": "error",
+      "kind": "type",
+      "message": "type mismatch: expected int, got string",
+      "span": { "start": 45, "end": 52, "start_line": 3, "start_col": 12, "end_line": 3, "end_col": 19 },
+      "path": null
+    }
+  ],
+  "warnings": []
+}
+```
+
+Diagnostic `kind` values: `"syntax"`, `"type"`, `"codegen"`, `"link"`, `"manifest"`.
+
+#### `compile`
+
+Compile a source file to a native binary.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Absolute path to the `.pluto` source file |
+| `output` | string | no | Output path for the binary (defaults to a temp file) |
+| `stdlib` | string | no | Path to stdlib root |
+
+**Returns:** `CompileResult`
+```json
+{
+  "success": true,
+  "path": "/path/to/file.pluto",
+  "output": "/tmp/pluto_binary_abc123",
+  "errors": []
+}
+```
+
+#### `run`
+
+Compile and execute a source file, capturing output.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Absolute path to the `.pluto` source file |
+| `stdlib` | string | no | Path to stdlib root |
+| `timeout_ms` | int | no | Execution timeout in milliseconds (default: 10000, max: 60000) |
+| `cwd` | string | no | Working directory for execution (default: source file's parent) |
+
+**Returns:** `RunResult`
+```json
+{
+  "success": true,
+  "path": "/path/to/file.pluto",
+  "compilation_errors": [],
+  "stdout": "hello world\n",
+  "stderr": "",
+  "exit_code": 0,
+  "timed_out": false
+}
+```
+
+If the program exceeds the timeout, `timed_out` is `true` and the process is killed.
+
+#### `test`
+
+Compile in test mode and run the test runner.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Absolute path to the `.pluto` source file containing tests |
+| `stdlib` | string | no | Path to stdlib root |
+| `timeout_ms` | int | no | Execution timeout (default: 30000, max: 60000) |
+| `cwd` | string | no | Working directory |
+
+**Returns:** `TestResult` (same shape as `RunResult`)
+
+Test output appears in `stdout`. A non-zero `exit_code` indicates test failures.
+
+---
+
+### Format & Sync
+
+#### `pretty_print`
+
+Pretty-print a loaded module or a specific declaration as Pluto source text.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the loaded module |
+| `uuid` | string | no | UUID of a specific declaration (omit for entire module) |
+| `include_uuid_hints` | bool | no | Include `// @uuid: ...` comments (default: false) |
+
+**Returns:** Formatted Pluto source text as string.
+
+With `include_uuid_hints: true`, each declaration is preceded by a UUID comment:
+```
+// @uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+fn add(a: int, b: int) int {
+    return a + b
+}
+```
+
+These hints enable stable UUID matching when syncing human edits back via `sync_pt`.
+
+#### `sync_pt`
+
+Sync human edits from a `.pt` text file back to a `.pluto` binary file, preserving UUIDs where declarations match by name.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `pt_path` | string | yes | Path to the `.pt` text file |
+| `pluto_path` | string | no | Path to the `.pluto` binary (defaults to same name with `.pluto` extension) |
+
+**Returns:** `SyncResultInfo`
+```json
+{
+  "added": ["new_function"],
+  "removed": ["old_function"],
+  "modified": ["updated_function"],
+  "unchanged": 3
+}
+```
+
+---
+
+### Module Management
+
+#### `reload_module`
+
+Discard the cached version of a module and reload it from disk. Use this after external edits.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | yes | Path of the module to reload |
+
+**Returns:** `ReloadResult`
+```json
+{ "path": "/path/to/file.pluto", "reloaded": true, "message": "Reloaded successfully" }
+```
+
+#### `module_status`
+
+Show the status of all loaded modules, including whether they've been modified on disk since loading.
+
+**Parameters:** None
+
+**Returns:** Array of `ModuleStatusEntry`
+```json
+[
+  { "path": "/path/to/main.pluto", "is_stale": false, "loaded_at": "2026-02-14T20:00:00Z" },
+  { "path": "/path/to/math.pluto", "is_stale": true, "loaded_at": "2026-02-14T19:30:00Z" }
+]
+```
+
+A module is `is_stale: true` when its file on disk has been modified more recently than when it was loaded.
+
+---
+
+### Documentation
+
+#### `docs`
+
+Get Pluto language reference documentation.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `topic` | string | no | Specific topic (omit for full reference) |
+
+**Available topics:** `types`, `operators`, `statements`, `declarations`, `strings`, `errors`, `closures`, `generics`, `modules`, `contracts`, `concurrency`, `gotchas`
+
+**Returns:** Markdown-formatted documentation.
+
+#### `stdlib_docs`
+
+Get standard library module documentation.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `module` | string | no | Module name (omit to list all modules) |
+
+**Available modules:** `strings`, `math`, `fs`, `json`, `http`, `net`, `socket`, `collections`, `io`, `random`, `time`
+
+**Returns:** Markdown-formatted API documentation with function signatures and descriptions.
+
+---
+
+## Data Types Reference
+
+### SpanInfo
+
+Source location information. Byte offsets are always present; line/column numbers are included when source text is available.
+
+```json
+{
+  "start": 45,
+  "end": 52,
+  "start_line": 3,
+  "start_col": 12,
+  "end_line": 3,
+  "end_col": 19
+}
+```
+
+Line and column numbers are 1-based.
+
+### DiagnosticInfo
+
+Compiler diagnostic (error or warning).
+
+```json
+{
+  "severity": "error",
+  "kind": "type",
+  "message": "type mismatch: expected int, got string",
+  "span": { "start": 45, "end": 52, "start_line": 3, "start_col": 12 },
+  "path": "/path/to/file.pluto"
+}
+```
+
+- `severity`: `"error"` or `"warning"`
+- `kind`: `"syntax"`, `"type"`, `"codegen"`, `"link"`, or `"manifest"`
+- `path`: Present for multi-file errors (e.g., sibling file parse failures)
+
+### DeclSummary
+
+Lightweight declaration reference.
+
+```json
+{ "name": "add", "uuid": "a1b2c3d4-...", "kind": "function" }
+```
+
+Kind values: `"function"`, `"class"`, `"enum"`, `"trait"`, `"error"`, `"app"`
+
+### DanglingRefInfo
+
+Reference left dangling after a deletion.
+
+```json
+{ "kind": "call", "name": "deleted_func", "span": { "start": 200, "end": 212 } }
+```


### PR DESCRIPTION
## Summary

- Add comprehensive MCP server tool reference (`docs/mcp-server.md`) covering all 30 tools with parameters, return types, and example JSON responses
- Add best practices guide (`docs/mcp-best-practices.md`) covering 10 categories of recommendations for AI agents working with the Pluto MCP server

## Documentation Structure

**Tool Reference** (`docs/mcp-server.md`):
- Setup and configuration instructions
- Quick start workflow
- Full reference for all tools organized by category: Project & Module Loading, Querying Declarations, Cross-References, Write Tools, Compile & Execute, Format & Sync, Module Management, Documentation
- Data types reference for shared output types

**Best Practices** (`docs/mcp-best-practices.md`):
- Project initialization patterns
- Explore-before-edit workflow
- Incremental validation after writes
- Write tool selection guide (when to use replace vs delete+add, etc.)
- File watching and staleness management
- Documentation-first development
- Cross-module refactoring workflow
- Safety practices (path safety, UUID stability)
- Performance tips
- Common anti-patterns to avoid