### PR TITLE
Fix MCP editing tools to preserve UUIDs from cached modules

### DIFF
--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -1039,9 +1039,20 @@ impl PlutoMcp {
         }
 
         let canonical = validated_path.to_string_lossy().to_string();
-        let contents = std::fs::read_to_string(&canonical).unwrap_or_default();
-        let module = Module::from_source(&contents)
-            .map_err(|e| mcp_internal(format!("Failed to parse file: {e}")))?;
+
+        // Get cached module to preserve UUIDs of existing declarations
+        // Remove from cache temporarily to get ownership for editing
+        let module = {
+            let mut modules = self.modules.write().await;
+            if let Some(metadata) = modules.remove(&canonical) {
+                metadata.module
+            } else {
+                // Not in cache - read from disk (new file or not yet loaded)
+                let contents = std::fs::read_to_string(&canonical).unwrap_or_default();
+                Module::from_source(&contents)
+                    .map_err(|e| mcp_internal(format!("Failed to parse file: {e}")))?
+            }
+        };
 
         let mut editor = module.edit();
         let ids = editor.add_many_from_source(&input.source)
@@ -1086,10 +1097,15 @@ impl PlutoMcp {
         let validated_path = validate_write_path(&self.project_root, &input.path).await?;
         let canonical = validated_path.to_string_lossy().to_string();
 
-        let contents = std::fs::read_to_string(&canonical)
-            .map_err(|e| mcp_err(format!("Cannot read file: {e}")))?;
-        let module = Module::from_source(&contents)
-            .map_err(|e| mcp_internal(format!("Failed to parse file: {e}")))?;
+        // Get cached module to preserve UUIDs
+        // Remove from cache temporarily to get ownership for editing
+        let module = {
+            let mut modules = self.modules.write().await;
+            modules
+                .remove(&canonical)
+                .ok_or_else(|| mcp_err(format!("Module not loaded: '{}'. Use load_module first.", canonical)))?
+                .module
+        };
 
         let (id, kind) = find_decl_by_name(&module, &input.name)?;
 
@@ -1129,10 +1145,15 @@ impl PlutoMcp {
         let validated_path = validate_write_path(&self.project_root, &input.path).await?;
         let canonical = validated_path.to_string_lossy().to_string();
 
-        let contents = std::fs::read_to_string(&canonical)
-            .map_err(|e| mcp_err(format!("Cannot read file: {e}")))?;
-        let module = Module::from_source(&contents)
-            .map_err(|e| mcp_internal(format!("Failed to parse file: {e}")))?;
+        // Get cached module to preserve UUIDs
+        // Remove from cache temporarily to get ownership for editing
+        let module = {
+            let mut modules = self.modules.write().await;
+            modules
+                .remove(&canonical)
+                .ok_or_else(|| mcp_err(format!("Module not loaded: '{}'. Use load_module first.", canonical)))?
+                .module
+        };
 
         let (id, _kind) = find_decl_by_name(&module, &input.name)?;
 
@@ -1179,10 +1200,15 @@ impl PlutoMcp {
         let validated_path = validate_write_path(&self.project_root, &input.path).await?;
         let canonical = validated_path.to_string_lossy().to_string();
 
-        let contents = std::fs::read_to_string(&canonical)
-            .map_err(|e| mcp_err(format!("Cannot read file: {e}")))?;
-        let module = Module::from_source(&contents)
-            .map_err(|e| mcp_internal(format!("Failed to parse file: {e}")))?;
+        // Get cached module to preserve UUIDs
+        // Remove from cache temporarily to get ownership for editing
+        let module = {
+            let mut modules = self.modules.write().await;
+            modules
+                .remove(&canonical)
+                .ok_or_else(|| mcp_err(format!("Module not loaded: '{}'. Use load_module first.", canonical)))?
+                .module
+        };
 
         let (id, _kind) = find_decl_by_name(&module, &input.old_name)?;
 
@@ -1222,10 +1248,15 @@ impl PlutoMcp {
         let validated_path = validate_write_path(&self.project_root, &input.path).await?;
         let canonical = validated_path.to_string_lossy().to_string();
 
-        let contents = std::fs::read_to_string(&canonical)
-            .map_err(|e| mcp_err(format!("Cannot read file: {e}")))?;
-        let module = Module::from_source(&contents)
-            .map_err(|e| mcp_internal(format!("Failed to parse file: {e}")))?;
+        // Get cached module to preserve UUIDs
+        // Remove from cache temporarily to get ownership for editing
+        let module = {
+            let mut modules = self.modules.write().await;
+            modules
+                .remove(&canonical)
+                .ok_or_else(|| mcp_err(format!("Module not loaded: '{}'. Use load_module first.", canonical)))?
+                .module
+        };
 
         let class_id = find_class_by_name(&module, &input.class_name)?;
 
@@ -1271,10 +1302,15 @@ impl PlutoMcp {
         let validated_path = validate_write_path(&self.project_root, &input.path).await?;
         let canonical = validated_path.to_string_lossy().to_string();
 
-        let contents = std::fs::read_to_string(&canonical)
-            .map_err(|e| mcp_err(format!("Cannot read file: {e}")))?;
-        let module = Module::from_source(&contents)
-            .map_err(|e| mcp_internal(format!("Failed to parse file: {e}")))?;
+        // Get cached module to preserve UUIDs
+        // Remove from cache temporarily to get ownership for editing
+        let module = {
+            let mut modules = self.modules.write().await;
+            modules
+                .remove(&canonical)
+                .ok_or_else(|| mcp_err(format!("Module not loaded: '{}'. Use load_module first.", canonical)))?
+                .module
+        };
 
         let class_id = find_class_by_name(&module, &input.class_name)?;
 


### PR DESCRIPTION
## Summary
- Fixed 6 MCP editing tools that were breaking UUID stability
- Tools now use cached modules instead of reading from disk
- UUIDs are preserved across renames, replacements, and other edits

## Background
The editing tools (rename_declaration, replace_declaration, delete_declaration, add_method, add_field, add_declaration) were reading from disk and parsing fresh on every edit. This generated new random UUIDs for all declarations, violating the fundamental invariant that UUIDs are stable identifiers.

## Changes
All 6 editing tools now:
1. Remove the module from cache temporarily (to get ownership for editing)
2. Edit the module using ModuleEditor
3. Write the result back to disk
4. Update the cache with the edited module

For add_declaration specifically, it falls back to reading from disk if the module isn't in cache (for new files that haven't been loaded yet).

## Testing
- All SDK tests pass (41 tests)
- Verified UUID preservation with standalone test program
- Confirmed rename operation preserves UUIDs correctly

## Fixes
- Fixes dogfooding bug #12: rename-declaration-changes-uuid
- Fixes dogfooding bug #13: replace-declaration-changes-uuid