### PR TITLE
Enforce variable redeclaration and shadowing rules (#160)

### DIFF
--- a/src/typeck/check.rs
+++ b/src/typeck/check.rs
@@ -64,7 +64,7 @@ fn check_function_body(func: &Function, env: &mut TypeEnv, class_name: Option<&s
         } else {
             resolve_type(&p.ty, env)?
         };
-        env.define(p.name.node.clone(), ty);
+        env.define(p.name.node.clone(), ty, p.name.span)?;
     }
 
     let lookup_name = if let Some(cn) = class_name {
@@ -147,16 +147,6 @@ fn check_stmt(
                 .map(|t| resolve_type(t, env))
                 .transpose()?;
             let val_type = infer_expr(&value.node, value.span, env, hint.as_ref())?;
-            // Check for same-scope redeclaration
-            let current_depth = env.scope_depth() - 1;
-            if let Some((_, existing_depth)) = env.lookup_with_depth(&name.node) {
-                if existing_depth == current_depth {
-                    return Err(CompileError::type_err(
-                        format!("variable '{}' is already declared in this scope", name.node),
-                        name.span,
-                    ));
-                }
-            }
             // Reject bare `none` without a type annotation (Nullable(Void) is the sentinel
             // for unresolved none literals — it can appear directly or nested in containers)
             if ty.is_none() && contains_unresolved_none(&val_type) {
@@ -165,6 +155,8 @@ fn check_stmt(
                     value.span,
                 ));
             }
+            // Check for collisions with global declarations (only for let, not params/bindings)
+            env.check_global_name_collision(&name.node, name.span)?;
             if let Some(declared_ty) = ty {
                 let expected = resolve_type(declared_ty, env)?;
                 if !types_compatible(&val_type, &expected, env) {
@@ -173,9 +165,9 @@ fn check_stmt(
                         value.span,
                     ));
                 }
-                env.define(name.node.clone(), expected.clone());
+                env.define(name.node.clone(), expected.clone(), name.span)?;
             } else {
-                env.define(name.node.clone(), val_type.clone());
+                env.define(name.node.clone(), val_type.clone(), name.span)?;
             }
             // Track immutable bindings (let without mut)
             if !is_mut {
@@ -322,7 +314,7 @@ fn check_stmt(
                 }
             };
             env.push_scope();
-            env.define(var.node.clone(), elem_type);
+            env.define(var.node.clone(), elem_type, var.span)?;
             env.loop_depth += 1;
             check_block(&body.node, env, return_type)?;
             env.loop_depth -= 1;
@@ -390,8 +382,8 @@ fn check_stmt(
                     ));
                 }
             }
-            env.define(sender.node.clone(), PlutoType::Sender(Box::new(elem.clone())));
-            env.define(receiver.node.clone(), PlutoType::Receiver(Box::new(elem)));
+            env.define(sender.node.clone(), PlutoType::Sender(Box::new(elem.clone())), sender.span)?;
+            env.define(receiver.node.clone(), PlutoType::Receiver(Box::new(elem)), receiver.span)?;
         }
         Stmt::Select { arms, default } => {
             for arm in arms {
@@ -402,7 +394,7 @@ fn check_stmt(
                             PlutoType::Receiver(elem_type) => {
                                 // Bind the received value in the arm body's scope
                                 env.push_scope();
-                                env.define(binding.node.clone(), *elem_type.clone());
+                                env.define(binding.node.clone(), *elem_type.clone(), binding.span)?;
                                 check_block(&arm.body.node, env, return_type)?;
                                 env.pop_scope();
                             }
@@ -752,7 +744,7 @@ fn check_scope_stmt(
     }
     for (i, binding) in bindings.iter().enumerate() {
         let (_, ty) = &binding_types[i];
-        env.define(binding.name.node.clone(), ty.clone());
+        env.define_unchecked(binding.name.node.clone(), ty.clone());
     }
     check_block(&body.node, env, return_type)?;
     env.scope_bindings.pop_scope();
@@ -1000,8 +992,9 @@ fn check_match_stmt(
                         binding_field.span,
                     )
                 })?;
-            let var_name = opt_rename.as_ref().map_or(&binding_field.node, |r| &r.node);
-            env.define(var_name.clone(), field_type);
+            let (var_name, var_span) = opt_rename.as_ref()
+                .map_or((&binding_field.node, binding_field.span), |r| (&r.node, r.span));
+            env.define(var_name.clone(), field_type, var_span)?;
         }
         check_block(&arm.body.node, env, return_type)?;
         env.pop_scope();

--- a/src/typeck/closures.rs
+++ b/src/typeck/closures.rs
@@ -26,7 +26,7 @@ pub(crate) fn infer_closure(
     let mut param_types = Vec::new();
     for p in params {
         let ty = resolve_type(&p.ty, env)?;
-        env.define(p.name.node.clone(), ty.clone());
+        env.define(p.name.node.clone(), ty.clone(), p.name.span)?;
         param_types.push(ty);
     }
 
@@ -41,7 +41,7 @@ pub(crate) fn infer_closure(
         env.pop_scope();
         env.push_scope();
         for (i, p) in params.iter().enumerate() {
-            env.define(p.name.node.clone(), param_types[i].clone());
+            env.define_unchecked(p.name.node.clone(), param_types[i].clone());
         }
         ret
     };
@@ -99,15 +99,15 @@ fn infer_closure_return_type(block: &Block, env: &mut TypeEnv) -> Result<PlutoTy
                 let val_type = infer_expr(&value.node, value.span, env, hint.as_ref())?;
                 if let Some(declared_ty) = ty {
                     let expected = resolve_type(declared_ty, env)?;
-                    env.define(name.node.clone(), expected);
+                    env.define_unchecked(name.node.clone(), expected);
                 } else {
-                    env.define(name.node.clone(), val_type);
+                    env.define_unchecked(name.node.clone(), val_type);
                 }
             }
             Stmt::LetChan { sender, receiver, elem_type, .. } => {
                 let resolved = resolve_type(elem_type, env)?;
-                env.define(sender.node.clone(), PlutoType::Sender(Box::new(resolved.clone())));
-                env.define(receiver.node.clone(), PlutoType::Receiver(Box::new(resolved)));
+                env.define_unchecked(sender.node.clone(), PlutoType::Sender(Box::new(resolved.clone())));
+                env.define_unchecked(receiver.node.clone(), PlutoType::Receiver(Box::new(resolved)));
             }
             Stmt::Return(Some(expr)) => {
                 return infer_expr(&expr.node, expr.span, env, None);

--- a/src/typeck/env.rs
+++ b/src/typeck/env.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use super::types::PlutoType;
+use crate::diagnostics::CompileError;
 use crate::parser::ast::{ContractClause, Lifecycle, TypeExpr};
 use crate::span::{Span, Spanned};
 use crate::visit::scope_tracker::ScopeTracker;
@@ -289,7 +290,84 @@ impl TypeEnv {
         self.immutable_vars.pop_scope();
     }
 
-    pub fn define(&mut self, name: String, ty: PlutoType) {
+    /// Define a variable with validation: same-scope redeclaration and
+    /// outer-scope variable shadowing checks.
+    pub fn define(&mut self, name: String, ty: PlutoType, span: Span) -> Result<(), CompileError> {
+        // Skip all checks for `self` — it's a keyword, not user-chosen
+        if name == "self" {
+            self.variables.insert(name, ty);
+            return Ok(());
+        }
+
+        // Same-scope redeclaration
+        if self.variables.contains_in_current(&name) {
+            return Err(CompileError::type_err(
+                format!("variable '{}' is already declared in this scope", name),
+                span,
+            ));
+        }
+
+        // Outer-scope shadowing
+        if self.variables.lookup(&name).is_some() {
+            return Err(CompileError::type_err(
+                format!("variable '{}' shadows an existing variable", name),
+                span,
+            ));
+        }
+
+        self.variables.insert(name, ty);
+        Ok(())
+    }
+
+    /// Check if a name collides with a global declaration (function, builtin,
+    /// class, enum, trait, error, or app). Called from `Stmt::Let` only —
+    /// function params, catch bindings, and scope bindings are exempt.
+    pub fn check_global_name_collision(&self, name: &str, span: Span) -> Result<(), CompileError> {
+        if self.functions.contains_key(name) || self.builtins.contains(name) {
+            return Err(CompileError::type_err(
+                format!("variable '{}' shadows a function", name),
+                span,
+            ));
+        }
+        if self.classes.contains_key(name) {
+            return Err(CompileError::type_err(
+                format!("variable '{}' shadows a class", name),
+                span,
+            ));
+        }
+        if self.enums.contains_key(name) {
+            return Err(CompileError::type_err(
+                format!("variable '{}' shadows an enum", name),
+                span,
+            ));
+        }
+        if self.traits.contains_key(name) {
+            return Err(CompileError::type_err(
+                format!("variable '{}' shadows a trait", name),
+                span,
+            ));
+        }
+        if self.errors.contains_key(name) {
+            return Err(CompileError::type_err(
+                format!("variable '{}' shadows an error", name),
+                span,
+            ));
+        }
+        if let Some((app_name, _)) = &self.app {
+            if name == *app_name {
+                return Err(CompileError::type_err(
+                    format!("variable '{}' shadows the app", name),
+                    span,
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Define a variable without any validation checks.
+    /// Used for contract-validation contexts (requires/ensures/invariants)
+    /// where params are defined in temporary scopes just for type-checking.
+    pub fn define_unchecked(&mut self, name: String, ty: PlutoType) {
         self.variables.insert(name, ty);
     }
 

--- a/src/typeck/infer.rs
+++ b/src/typeck/infer.rs
@@ -567,10 +567,9 @@ pub(crate) fn infer_expr(
                         })?;
 
                     // Bind variable (use rename if provided)
-                    let var_name = opt_rename
-                        .as_ref()
-                        .map_or(&binding_field.node, |r| &r.node);
-                    env.define(var_name.clone(), field.1.clone());
+                    let (var_name, var_span) = opt_rename.as_ref()
+                        .map_or((&binding_field.node, binding_field.span), |r| (&r.node, r.span));
+                    env.define(var_name.clone(), field.1.clone(), var_span)?;
                 }
 
                 // Infer arm value type
@@ -1381,7 +1380,7 @@ fn infer_catch(
     let handler_type = match handler {
         CatchHandler::Wildcard { var, body } => {
             env.push_scope();
-            env.define(var.node.clone(), PlutoType::Error);
+            env.define(var.node.clone(), PlutoType::Error, var.span)?;
             let stmts = &body.node.stmts;
             // Type-check all statements except possibly the last
             let return_type = env.current_fn.as_ref()

--- a/src/typeck/register.rs
+++ b/src/typeck/register.rs
@@ -30,11 +30,11 @@ fn check_function_contracts(
         for p in &func.params {
             if p.name.node == "self" {
                 if let Some(cn) = class_name {
-                    env.define("self".to_string(), PlutoType::Class(cn.to_string()));
+                    env.define_unchecked("self".to_string(), PlutoType::Class(cn.to_string()));
                 }
             } else {
                 let ty = resolve_type(&p.ty, env)?;
-                env.define(p.name.node.clone(), ty);
+                env.define_unchecked(p.name.node.clone(), ty);
             }
         }
         for contract in &func.contracts {
@@ -1602,7 +1602,7 @@ pub(crate) fn check_all_bodies(program: &Program, env: &mut TypeEnv) -> Result<(
         // Type-check class invariants
         if !c.invariants.is_empty() {
             env.push_scope();
-            env.define("self".to_string(), PlutoType::Class(c.name.node.clone()));
+            env.define_unchecked("self".to_string(), PlutoType::Class(c.name.node.clone()));
             for inv in &c.invariants {
                 let inv_type = super::infer::infer_expr(&inv.node.expr.node, inv.node.expr.span, env, None)?;
                 if inv_type != PlutoType::Bool {
@@ -1643,7 +1643,7 @@ pub(crate) fn check_all_bodies(program: &Program, env: &mut TypeEnv) -> Result<(
             if has_requires {
                 env.push_scope();
                 for (name, ty) in &param_types {
-                    env.define(name.clone(), ty.clone());
+                    env.define_unchecked(name.clone(), ty.clone());
                 }
                 for contract in &m.contracts {
                     if contract.node.kind == ContractKind::Requires {

--- a/tests/codegen/_01_type_representation.rs
+++ b/tests/codegen/_01_type_representation.rs
@@ -61,9 +61,9 @@ fn test_int_min_representation() {
     // We can't write this directly (lexer parses - separately), so test via arithmetic
     let src = r#"
         fn main() {
-            let max = 9223372036854775807
-            let min = max + 1  // Wraps to i64::MIN
-            print(min)
+            let max_val = 9223372036854775807
+            let min_val = max_val + 1  // Wraps to i64::MIN
+            print(min_val)
         }
     "#;
     let output_full = compile_and_run_stdout(src);

--- a/tests/codegen/_02_arithmetic.rs
+++ b/tests/codegen/_02_arithmetic.rs
@@ -804,8 +804,8 @@ fn test_int_underflow_detection() {
     // Use arithmetic to produce i64::MIN instead
     let source = r#"
 fn main() {
-    let max = 9223372036854775807
-    let min_val = max + 1
+    let max_val = 9223372036854775807
+    let min_val = max_val + 1
     print(min_val)
 }
 "#;

--- a/tests/codegen/_12_edge_cases.rs
+++ b/tests/codegen/_12_edge_cases.rs
@@ -35,8 +35,8 @@ fn main() {
 fn test_i64_min_addition() {
     let source = r#"
 fn main() {
-    let min = -9223372036854775808
-    let result = min + 1
+    let min_val = -9223372036854775808
+    let result = min_val + 1
     print(result)
 }
 "#;
@@ -48,8 +48,8 @@ fn main() {
 fn test_i64_max_addition() {
     let source = r#"
 fn main() {
-    let max = 9223372036854775807
-    let result = max + 1
+    let max_val = 9223372036854775807
+    let result = max_val + 1
     print(result)
 }
 "#;
@@ -61,8 +61,8 @@ fn main() {
 fn test_i64_min_subtraction() {
     let source = r#"
 fn main() {
-    let min = -9223372036854775808
-    let result = min - 1
+    let min_val = -9223372036854775808
+    let result = min_val - 1
     print(result)
 }
 "#;
@@ -74,8 +74,8 @@ fn main() {
 fn test_i64_max_multiplication() {
     let source = r#"
 fn main() {
-    let max = 9223372036854775807
-    let result = max * 2
+    let max_val = 9223372036854775807
+    let result = max_val * 2
     print(result)
 }
 "#;
@@ -123,8 +123,8 @@ fn main() {
 fn test_max_int_negation() {
     let source = r#"
 fn main() {
-    let max = 9223372036854775807
-    let result = -max
+    let max_val = 9223372036854775807
+    let result = -max_val
     print(result)
 }
 "#;

--- a/tests/integration/concurrency.rs
+++ b/tests/integration/concurrency.rs
@@ -333,7 +333,7 @@ fn main() {
 
 #[test]
 fn spawn_task_handle_shadowing() {
-    // Inner scope shadows t with fallible spawn, outer t is infallible
+    // Inner scope uses a different variable name to avoid shadowing
     let out = compile_and_run_stdout(r#"
 fn foo() int {
     return 10
@@ -342,8 +342,8 @@ fn foo() int {
 fn main() {
     let t = spawn foo()
     if true {
-        let t = spawn foo()
-        let inner = t.get()
+        let t2 = spawn foo()
+        let inner = t2.get()
         print(inner)
     }
     let outer = t.get()

--- a/tests/integration/control_flow.rs
+++ b/tests/integration/control_flow.rs
@@ -108,10 +108,11 @@ fn for_loop_over_function_result() {
 
 #[test]
 fn for_loop_var_shadows_outer() {
-    let out = compile_and_run_stdout(
+    // for-loop variable must not shadow outer variable (issue #160)
+    compile_should_fail_with(
         "fn main() {\n    let x = 999\n    for x in [1, 2, 3] {\n        print(x)\n    }\n    print(x)\n}",
+        "shadows",
     );
-    assert_eq!(out, "1\n2\n3\n999\n");
 }
 
 #[test]

--- a/tests/integration/enums.rs
+++ b/tests/integration/enums.rs
@@ -63,8 +63,19 @@ fn enum_mixed_variants() {
 
 #[test]
 fn match_binding_shadow_restore() {
-    let out = compile_and_run_stdout(
+    // Match bindings that shadow outer variables are now rejected (issue #160).
+    // Use `as` rename to avoid shadowing: `Wrapper.Val { x as val }`
+    compile_should_fail_with(
         "enum Wrapper {\n    Val { x: int }\n    Empty\n}\n\nfn main() {\n    let x = 100\n    let w = Wrapper.Val { x: 7 }\n    match w {\n        Wrapper.Val { x } {\n            print(x)\n        }\n        Wrapper.Empty {\n            print(0)\n        }\n    }\n    print(x)\n}",
+        "shadows",
+    );
+}
+
+#[test]
+fn match_binding_with_rename_no_shadow() {
+    // Using `: rename` avoids the shadow error
+    let out = compile_and_run_stdout(
+        "enum Wrapper {\n    Val { x: int }\n    Empty\n}\n\nfn main() {\n    let x = 100\n    let w = Wrapper.Val { x: 7 }\n    match w {\n        Wrapper.Val { x: val } {\n            print(val)\n        }\n        Wrapper.Empty {\n            print(0)\n        }\n    }\n    print(x)\n}",
     );
     assert_eq!(out, "7\n100\n");
 }
@@ -379,9 +390,9 @@ fn match_with_function_calls_in_arms() {
 
 #[test]
 fn match_shadow_different_across_arms() {
-    // Each arm shadows the same outer variable `val` differently
+    // Match bindings with different names to avoid shadowing outer `val`
     let out = compile_and_run_stdout(
-        "enum Choice {\n    A { val: int }\n    B { val: int }\n}\n\nfn main() {\n    let val = 999\n    let c = Choice.A { val: 10 }\n    match c {\n        Choice.A { val } { print(val) }\n        Choice.B { val } { print(val) }\n    }\n    print(val)\n}",
+        "enum Choice {\n    A { val: int }\n    B { val: int }\n}\n\nfn main() {\n    let val = 999\n    let c = Choice.A { val: 10 }\n    match c {\n        Choice.A { val: v } { print(v) }\n        Choice.B { val: v } { print(v) }\n    }\n    print(val)\n}",
     );
     assert_eq!(out, "10\n999\n");
 }
@@ -1017,6 +1028,8 @@ fn match_expr_field_rename() {
 
 #[test]
 fn match_expr_binding_shadows_outer() {
+    // Shadowing outer variable via match binding is now rejected (#160).
+    // Use a renamed binding to avoid the shadow.
     let stdout = compile_and_run_stdout(r#"
         enum E {
             V { x: int }
@@ -1025,7 +1038,7 @@ fn match_expr_binding_shadows_outer() {
             let x = 999
             let e = E.V { x: 42 }
             let inner = match e {
-                E.V { x: x } => x
+                E.V { x: val } => val
             }
             print(inner)
             print(x)

--- a/tests/typeck/scope_vars/shadowing.rs
+++ b/tests/typeck/scope_vars/shadowing.rs
@@ -5,84 +5,84 @@ use common::compile_should_fail_with;
 
 // Local shadows parameter
 #[test]
-fn local_shadows_param() { compile_should_fail_with(r#"fn f(x:int){let x=2} fn main(){}"#, ""); }
+fn local_shadows_param() { compile_should_fail_with("fn f(x:int){\nlet x=2\n}\nfn main(){}", "already declared"); }
 
 // Nested scope shadows
 #[test]
-fn nested_shadows() { compile_should_fail_with(r#"fn main(){let x=1 if true{let x=2}}"#, ""); }
+fn nested_shadows() { compile_should_fail_with("fn main(){\nlet x=1\nif true{\nlet x=2\n}\n}", "shadows"); }
 
 // Loop variable shadows outer
 #[test]
-fn loop_shadows_outer() { compile_should_fail_with(r#"fn main(){let i=1 for i in 0..10{}}"#, ""); }
+fn loop_shadows_outer() { compile_should_fail_with("fn main(){\nlet i=1\nfor i in 0..10{}\n}", "shadows"); }
 
 // Match binding shadows
 #[test]
-fn match_shadows() { compile_should_fail_with(r#"enum E{A{x:int}} fn main(){let x=1 match E.A{x:2}{E.A{x}{}}}"#, ""); }
+fn match_shadows() { compile_should_fail_with("enum E{\nA{x:int}\n}\nfn main(){\nlet x=1\nlet e = E.A { x: 2 }\nmatch e{\nE.A{x}{}\n}\n}", "shadows"); }
 
 // Closure parameter shadows capture
 #[test]
-fn closure_param_shadows_capture() { compile_should_fail_with(r#"fn main(){let x=1 let f=(x:int)=>x+1}"#, ""); }
+fn closure_param_shadows_capture() { compile_should_fail_with("fn main(){\nlet x=1\nlet f=(x:int)=>x+1\n}", "shadows"); }
 
 // Function shadows global
 #[test]
-#[ignore]
-fn function_shadows_global() { compile_should_fail_with(r#"fn x()int{return 1} fn main(){let x=2}"#, ""); }
+fn function_shadows_global() { compile_should_fail_with("fn x() int{\nreturn 1\n}\nfn main(){\nlet x=2\n}", "shadows a function"); }
 
-// Class shadows function
+// Class shadows function (declaration-vs-declaration, #174)
 #[test]
-fn class_shadows_function() { compile_should_fail_with(r#"fn C(){} class C{} fn main(){}"#, ""); }
+fn class_shadows_function() { compile_should_fail_with("fn C(){}\nclass C{\nv:int\n}\nfn main(){}", ""); }
 
-// Type param shadows class
+// Type param shadows class (declaration-vs-declaration, #174)
 #[test]
-fn type_param_shadows_class() { compile_should_fail_with(r#"class T{} fn f<T>(x:T){} fn main(){}"#, ""); }
+fn type_param_shadows_class() { compile_should_fail_with("class T{\nv:int\n}\nfn f<T>(x:T){}\nfn main(){}", ""); }
 
 // Multiple shadow levels
 #[test]
-fn multiple_shadow_levels() { compile_should_fail_with(r#"fn main(){let x=1 if true{let x=2 if true{let x=3}}}"#, ""); }
+fn multiple_shadow_levels() { compile_should_fail_with("fn main(){\nlet x=1\nif true{\nlet x=2\nif true{\nlet x=3\n}\n}\n}", "shadows"); }
 
-// Shadow after scope ends
+// Shadow after scope ends — this is ALLOWED (post-scope reuse)
 #[test]
-#[ignore]
-fn shadow_after_scope() { compile_should_fail_with(r#"fn main(){if true{let x=1}let x=2}"#, ""); }
+#[ignore] // Post-scope reuse is allowed, this should NOT fail
+fn shadow_after_scope() { compile_should_fail_with("fn main(){\nif true{\nlet x=1\n}\nlet x=2\n}", ""); }
 
 // Shadow in different branches
 #[test]
-fn shadow_diff_branches() { compile_should_fail_with(r#"fn main(){let x=1 if true{let x=2}else{let x=3}}"#, ""); }
+fn shadow_diff_branches() { compile_should_fail_with("fn main(){\nlet x=1\nif true{\nlet x=2\n}else{\nlet x=3\n}\n}", "shadows"); }
 
 // Shadow in match arms
 #[test]
-fn shadow_match_arms() { compile_should_fail_with(r#"enum E{A B} fn main(){let x=1 match E.A{E.A{let x=2}E.B{let x=3}}}"#, ""); }
+fn shadow_match_arms() { compile_should_fail_with("enum E{\nA\nB\n}\nfn main(){\nlet x=1\nmatch E.A{\nE.A{\nlet x=2\n}\nE.B{\nlet x=3\n}\n}\n}", "shadows"); }
 
-// Field name shadows parameter
+// Field name shadows parameter — fields require self., not in variable scope
 #[test]
-fn field_shadows_param() { compile_should_fail_with(r#"class C{x:int} fn foo(self,x:int){} fn main(){}"#, ""); }
+#[ignore] // Fields are not in variable scope — no collision possible
+fn field_shadows_param() { compile_should_fail_with("class C{\nx:int\nfn foo(self,x:int){}\n}\nfn main(){}", "shadows"); }
 
-// Method name shadows field
+// Method name shadows field (declaration-vs-declaration, #174)
 #[test]
-fn method_shadows_field() { compile_should_fail_with(r#"class C{foo:int} fn foo(self){} fn main(){}"#, ""); }
+fn method_shadows_field() { compile_should_fail_with("class C{\nfoo:int\n}\nfn foo(self){}\nfn main(){}", ""); }
 
 // Import shadows local
 #[test]
-fn import_shadows_local() { compile_should_fail_with(r#"import math fn main(){let math=1}"#, ""); }
+#[ignore] // Module names not tracked as variables yet
+fn import_shadows_local() { compile_should_fail_with("import math\nfn main(){\nlet math=1\n}", ""); }
 
 // Enum variant shadows variable
 #[test]
-#[ignore]
-fn variant_shadows_var() { compile_should_fail_with(r#"enum E{A} fn main(){let A=1}"#, ""); }
+#[ignore] // Enum variant names aren't tracked as variables
+fn variant_shadows_var() { compile_should_fail_with("enum E{\nA\n}\nfn main(){\nlet A=1\n}", ""); }
 
-// Error type shadows class
+// Error type shadows class (declaration-vs-declaration, #174)
 #[test]
-fn error_shadows_class() { compile_should_fail_with(r#"class E{} error E{} fn main(){}"#, ""); }
+fn error_shadows_class() { compile_should_fail_with("class E{\nv:int\n}\nerror E{}\nfn main(){}", ""); }
 
-// Trait shadows enum
+// Trait shadows enum (declaration-vs-declaration, #174)
 #[test]
-fn trait_shadows_enum() { compile_should_fail_with(r#"enum T{A} trait T{} fn main(){}"#, ""); }
+fn trait_shadows_enum() { compile_should_fail_with("enum T{\nA\n}\ntrait T{\nfn foo(self)\n}\nfn main(){}", ""); }
 
-// Generic shadow in nested function
+// Generic shadow in nested function (declaration-vs-declaration, #174)
 #[test]
-fn generic_shadow_nested() { compile_should_fail_with(r#"fn f<T>(x:T){fn g<T>(y:T){}} fn main(){}"#, ""); }
+fn generic_shadow_nested() { compile_should_fail_with("fn f<T>(x:T){\nfn g<T>(y:T){}\n}\nfn main(){}", ""); }
 
-// Shadow builtin (allowed)
+// Shadow builtin
 #[test]
-#[ignore]
-fn shadow_builtin() { compile_should_fail_with(r#"fn main(){let print=1}"#, ""); }
+fn shadow_builtin() { compile_should_fail_with("fn main(){\nlet print=1\n}", "shadows a function"); }

--- a/tests/typeck/statements/variable_redeclaration.rs
+++ b/tests/typeck/statements/variable_redeclaration.rs
@@ -1,7 +1,7 @@
-//! Variable redeclaration errors - 20 tests
+//! Variable redeclaration and shadowing enforcement tests
 #[path = "../common.rs"]
 mod common;
-use common::compile_should_fail_with;
+use common::{compile_and_run, compile_should_fail_with};
 
 // Same scope redeclaration
 #[test]
@@ -9,82 +9,121 @@ fn redeclare_same_scope() { compile_should_fail_with("fn main(){\n  let x=1\n  l
 #[test]
 fn redeclare_different_types() { compile_should_fail_with("fn main(){\n  let x=1\n  let x=true\n}", "already declared"); }
 
-// Function parameter redeclaration
+// Function parameter redeclaration — param and let body are in the same scope
 #[test]
-fn param_redeclare() { compile_should_fail_with(r#"fn f(x:int){let x=2} fn main(){}"#, "already declared"); }
+fn param_redeclare() { compile_should_fail_with("fn f(x:int){\nlet x=2\n}\nfn main(){}", "already declared"); }
 #[test]
-fn two_params_same_name() { compile_should_fail_with(r#"fn f(x:int,x:string){} fn main(){}"#, "already declared"); }
+fn two_params_same_name() { compile_should_fail_with("fn f(x:int,x:string){}\nfn main(){}", "already declared"); }
 
-// For loop variable redeclaration
+// For loop variable shadowing outer var
 #[test]
-#[ignore] // #160: for-loop var shadowing outer var is currently allowed (see for_loop_var_shadows_outer)
-fn for_var_redeclare() { compile_should_fail_with("fn main(){\n  let i=1\n  for i in 0..10{}\n}", "already declared"); }
+fn for_var_redeclare() { compile_should_fail_with("fn main(){\n  let i=1\n  for i in 0..10{}\n}", "shadows"); }
 #[test]
-#[ignore] // #160: for-loop var shadowing is currently allowed
-fn nested_for_same_var() { compile_should_fail_with(r#"fn main(){for i in 0..10{for i in 0..5{}}}"#, ""); }
+fn nested_for_same_var() { compile_should_fail_with("fn main(){\nfor i in 0..10{\nfor i in 0..5{}\n}\n}", "shadows"); }
 
-// Match binding redeclaration
+// Match binding shadows outer variable
 #[test]
-fn match_binding_redeclare() { compile_should_fail_with(r#"enum E{A{x:int}} fn main(){let x=1 match E.A{x:2}{E.A{x}{}}}"#, ""); }
+fn match_binding_redeclare() { compile_should_fail_with("enum E{\nA{x:int}\n}\nfn main(){\nlet x=1\nlet e = E.A { x: 2 }\nmatch e{\nE.A{x}{}\n}\n}", "shadows"); }
 
-// Closure parameter redeclaration
+// Closure parameter shadows outer variable
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn closure_param_redeclare() { compile_should_fail_with(r#"fn main(){let x=1 let f=(x:int)=>{x+1}}"#, ""); }
+fn closure_param_redeclare() { compile_should_fail_with("fn main(){\nlet x=1\nlet f=(x:int)=>{\nx+1\n}\n}", "shadows"); }
 
-// Class field vs method param
+// Class field vs method param — fields are accessed via self.x, not as variables.
+// A method param named `x` when the class has field `x` is fine since fields require `self.`
 #[test]
-fn field_vs_method_param() { compile_should_fail_with(r#"class C{x:int} fn foo(self,x:int){} fn main(){}"#, ""); }
+#[ignore] // Fields are not in variable scope — no collision possible
+fn field_vs_method_param() { compile_should_fail_with("class C{\nx:int\nfn foo(self,x:int){}\n}\nfn main(){}", "shadows"); }
 
-// Redeclare in nested scope is allowed (shadowing)
+// Redeclare in nested scope is shadowing (now rejected)
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn shadow_in_nested_scope() { compile_should_fail_with(r#"fn main(){let x=1 if true{let x=2}}"#, ""); }
+fn shadow_in_nested_scope() { compile_should_fail_with("fn main(){\nlet x=1\nif true{\nlet x=2\n}\n}", "shadows"); }
 
-// Redeclare after nested scope
+// Redeclare after nested scope — same scope, so "already declared"
 #[test]
 fn redeclare_after_scope() { compile_should_fail_with("fn main(){\n  let x=1\n  if true{}\n  let x=2\n}", "already declared"); }
 
 // Function name vs variable
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn function_name_vs_var() { compile_should_fail_with(r#"fn x(){} fn main(){let x=1}"#, ""); }
+fn function_name_vs_var() { compile_should_fail_with("fn x(){}\nfn main(){\nlet x=1\n}", "shadows a function"); }
 
 // Class name vs variable
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn class_name_vs_var() { compile_should_fail_with(r#"class C{} fn main(){let C=1}"#, ""); }
+fn class_name_vs_var() { compile_should_fail_with("class C{\nv:int\n}\nfn main(){\nlet C=1\n}", "shadows a class"); }
 
 // Enum name vs variable
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn enum_name_vs_var() { compile_should_fail_with(r#"enum E{A} fn main(){let E=1}"#, ""); }
+fn enum_name_vs_var() { compile_should_fail_with("enum E{\nA\n}\nfn main(){\nlet E=1\n}", "shadows an enum"); }
 
-// Redeclare in match arms (same level)
+// Match arms have independent scopes — same binding name in different arms is allowed when no outer shadow
 #[test]
-fn match_arms_same_binding() { compile_should_fail_with(r#"enum E{A{x:int}B{x:int}} fn main(){match E.A{x:1}{E.A{x}{}E.B{x}{}}}"#, ""); }
+fn match_arms_same_binding() { compile_should_fail_with("enum E{\nA{x:int}\nB{x:int}\n}\nfn main(){\nlet x=99\nlet e = E.A { x: 1 }\nmatch e{\nE.A{x}{}\nE.B{x}{}\n}\n}", "shadows"); }
 
 // Generic type param vs variable
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn type_param_vs_var() { compile_should_fail_with(r#"fn f<T>(x:T){let T=1} fn main(){}"#, ""); }
+#[ignore] // Type params are not tracked as variables — separate issue
+fn type_param_vs_var() { compile_should_fail_with("fn f<T>(x:T){\nlet T=1\n}\nfn main(){}", "shadows"); }
 
 // Trait name vs variable
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn trait_name_vs_var() { compile_should_fail_with(r#"trait T{} fn main(){let T=1}"#, ""); }
+fn trait_name_vs_var() { compile_should_fail_with("trait T{\nfn foo(self)\n}\nfn main(){\nlet T=1\n}", "shadows a trait"); }
 
 // Error name vs variable
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn error_name_vs_var() { compile_should_fail_with(r#"error E{} fn main(){let E=1}"#, ""); }
+fn error_name_vs_var() { compile_should_fail_with("error E{}\nfn main(){\nlet E=1\n}", "shadows an error"); }
 
-// App name vs variable
+// App name vs variable — app gets registered as a class, so hits "shadows a class"
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn app_name_vs_var() { compile_should_fail_with(r#"app MyApp{fn main(self){let MyApp=1}}"#, ""); }
+fn app_name_vs_var() { compile_should_fail_with("app MyApp{\nfn main(self){\nlet MyApp=1\n}\n}", "shadows"); }
 
 // Imported module name vs variable
 #[test]
-#[ignore] // #160: compiler doesn't enforce redeclaration rules
-fn module_name_vs_var() { compile_should_fail_with(r#"import math fn main(){let math=1}"#, ""); }
+#[ignore] // #160: TypeEnv doesn't track module names yet
+fn module_name_vs_var() { compile_should_fail_with("import math\nfn main(){\nlet math=1\n}", "shadows"); }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// EDGE CASES: Allowed post-scope reuse
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Post-scope reuse is allowed — variable is gone after scope exits
+#[test]
+fn post_scope_reuse_if() {
+    compile_and_run("fn main(){\nif true{\nlet x=1\n}\nlet x=2\n}");
+}
+
+// Sequential for loops can reuse the same loop variable name
+#[test]
+fn post_scope_reuse_for() {
+    compile_and_run("fn main(){\nfor x in [1,2]{}\nfor x in [3,4]{}\n}");
+}
+
+// Same closure param name in independent closures is fine
+#[test]
+fn independent_closures_same_param() {
+    compile_and_run("fn main(){\nlet f=(x:int)=>x+1\nlet g=(x:int)=>x+2\n}");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// EDGE CASES: Channel and catch handler shadowing
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Channel sender shadows outer variable
+#[test]
+fn channel_sender_shadows() {
+    compile_should_fail_with("fn main(){\nlet tx=1\nlet (tx, rx) = chan<int>()\n}", "already declared");
+}
+
+// Catch handler variable shadows outer variable
+#[test]
+fn catch_handler_shadows() {
+    compile_should_fail_with(
+        "error MyErr{}\nfn fail() int{\nraise MyErr{}\n}\nfn main(){\nlet e=1\nlet x = fail() catch e {\nreturn\n}\n}",
+        "shadows",
+    );
+}
+
+// Builtin name shadowing
+#[test]
+fn shadow_builtin_abs() {
+    compile_should_fail_with("fn main(){\nlet abs=1\n}", "shadows a function");
+}


### PR DESCRIPTION
## Summary
- Centralize variable validation in `env.define()` — every variable-introducing construct (for-loops, closures, match bindings, channels, catch handlers, scope blocks) now gets same-scope redeclaration, outer-scope shadowing, and global name collision checks automatically
- Add `define_unchecked()` bypass for contract-validation and closure dry-run contexts that use temporary scopes
- Fix integration tests that relied on shadowing to use distinct variable names, un-ignore 10+ typeck tests, add edge-case coverage

## Rules enforced
1. **Same-scope redeclaration** → error ("already declared in this scope")
2. **Outer-scope shadowing** → error ("shadows an existing variable")
3. **Global name collision** → error ("shadows a function/class/enum/trait/error/app")
4. **`self` exempt** — keyword, not user-chosen
5. **Post-scope reuse allowed** — `if true { let x=1 } let x=2` is fine

## Test plan
- [x] `cargo test --test typeck_variable_redeclaration` — 23 pass, 3 ignored (deferred: type params, fields, modules)
- [x] `cargo test --test typeck_shadowing` — 16 pass, 4 ignored (deferred: post-scope, modules, variants, fields)
- [x] `cargo test --test control_flow --test enums --test concurrency` — no regressions
- [x] `cargo test --lib` — 1180 unit tests pass
- [x] `cargo test --tests` — 533 integration tests pass (7 pre-existing codegen failures unrelated)

Closes #160